### PR TITLE
Soviet AI should have more reserves

### DIFF
--- a/common/decisions/SOV.txt
+++ b/common/decisions/SOV.txt
@@ -17058,12 +17058,12 @@ SOV_great_patriotic_war = {
 					}
 				}
 			}
-			572 = {
+			capital_scope = {
 				create_unit = {
 					division = "division_template = \"Rifle Division\" start_experience_factor = 0.2 start_equipment_factor=0.75"
 					owner = SOV
 					count = 12
-					prioritize_location = 9292
+					prioritize_location = 6380
 				}
 			}
 		}

--- a/common/decisions/reserves.txt
+++ b/common/decisions/reserves.txt
@@ -180,41 +180,51 @@ reserve_divisions = {
 				has_country_flag = reserve_total_9
 				has_army_manpower = { size > 999999 }
 			}
-#			if = {
-#				limit = {
-#					has_country_flag = reserve_total_10
-#				}
-#				has_country_flag = reserve_total_10
-#				has_army_manpower = { size > 1999999 }
-#			}
-#			if = {
-#				limit = {
-#					has_country_flag = reserve_total_11
-#				}
-#				has_country_flag = reserve_total_11
-#				has_army_manpower = { size > 1999999 }
-#			}
-#			if = {
-#				limit = {
-#					has_country_flag = reserve_total_12
-#				}
-#				has_country_flag = reserve_total_12
-#				has_army_manpower = { size > 1999999 }
-#			}
-#			if = {
-#				limit = {
-#					has_country_flag = reserve_total_13
-#				}
-#				has_country_flag = reserve_total_13
-#				has_army_manpower = { size > 1999999 }
-#			}
-#			if = {
-#				limit = {
-#					has_country_flag = reserve_total_14
-#				}
-#				has_country_flag = reserve_total_14
-#				has_army_manpower = { size > 1999999 }
-#			}
+			if = {
+				limit = {
+					has_country_flag = reserve_total_10
+					tag = SOV
+					is_ai = yes
+				}
+				has_country_flag = reserve_total_10
+				has_army_manpower = { size > 1999999 }
+			}
+			if = {
+				limit = {
+					has_country_flag = reserve_total_11
+					tag = SOV
+					is_ai = yes
+				}
+				has_country_flag = reserve_total_11
+				has_army_manpower = { size > 1999999 }
+			}
+			if = {
+				limit = {
+					has_country_flag = reserve_total_12
+					tag = SOV
+					is_ai = yes
+				}
+				has_country_flag = reserve_total_12
+				has_army_manpower = { size > 1999999 }
+			}
+			if = {
+				limit = {
+					has_country_flag = reserve_total_13
+					tag = SOV
+					is_ai = yes
+				}
+				has_country_flag = reserve_total_13
+				has_army_manpower = { size > 1999999 }
+			}
+			if = {
+				limit = {
+					has_country_flag = reserve_total_14
+					tag = SOV
+					is_ai = yes
+				}
+				has_country_flag = reserve_total_14
+				has_army_manpower = { size > 1999999 }
+			}
 			if = {
 				limit = {
 					NOT = {
@@ -237,12 +247,16 @@ reserve_divisions = {
 				has_army_manpower = { size > 199999 }
 			}
 			has_war = no
-			NOT = { has_country_flag = reserve_total_10 }
-			NOT = { has_country_flag = reserve_total_11 }
-			NOT = { has_country_flag = reserve_total_12 }
-			NOT = { has_country_flag = reserve_total_13 }
-			NOT = { has_country_flag = reserve_total_14 }
-			NOT = { has_country_flag = reserve_total_15 }
+			if = {
+				limit = {
+					tag = SOV
+					is_ai = yes
+				}
+				NOT = { has_country_flag = reserve_total_15 }
+			}
+			else = {
+				NOT = { has_country_flag = reserve_total_10 }
+			}
 		}
 
 		visible = {
@@ -317,8 +331,31 @@ reserve_divisions = {
 		}
 
 		modifier = {
-			industrial_capacity_factory = -0.15
-			training_time_factor = 1.0
+			if = {
+				limit = {
+					NOT = {
+						tag = SOV
+					}
+				}
+				industrial_capacity_factory = -0.15
+				training_time_factor = 1.0
+			}
+			if = {
+				limit = {
+					tag = SOV
+					is_ai = yes
+				}
+				industrial_capacity_factory = -0.15
+				training_time_factor = 0.5
+			}
+			if = {
+				limit = {
+					tag = SOV
+					is_ai = no
+				}
+				industrial_capacity_factory = -0.15
+				training_time_factor = 1.0
+			}
 		}
 
 		remove_effect = {
@@ -388,41 +425,51 @@ reserve_divisions = {
 					clr_country_flag = reserve_total_9
 					set_country_flag = reserve_total_10
 				}
-#				else_if = {
-#					limit = {
-#						has_country_flag = reserve_total_10
-#					}
-#					clr_country_flag = reserve_total_10
-#					set_country_flag = reserve_total_11
-#				}
-#				else_if = {
-#					limit = {
-#						has_country_flag = reserve_total_11
-#					}
-#					clr_country_flag = reserve_total_11
-#					set_country_flag = reserve_total_12
-#				}
-#				else_if = {
-#					limit = {
-#						has_country_flag = reserve_total_12
-#					}
-#					clr_country_flag = reserve_total_12
-#					set_country_flag = reserve_total_13
-#				}
-#				else_if = {
-#					limit = {
-#						has_country_flag = reserve_total_13
-#					}
-#					clr_country_flag = reserve_total_13
-#					set_country_flag = reserve_total_14
-#				}
-#				else_if = {
-#					limit = {
-#						has_country_flag = reserve_total_14
-#					}
-#					clr_country_flag = reserve_total_14
-#					set_country_flag = reserve_total_15
-#				}
+				else_if = {
+					limit = {
+						has_country_flag = reserve_total_10
+						tag = SOV
+						is_ai = yes
+					}
+					clr_country_flag = reserve_total_10
+					set_country_flag = reserve_total_11
+				}
+				else_if = {
+					limit = {
+						has_country_flag = reserve_total_11
+						tag = SOV
+						is_ai = yes
+					}
+					clr_country_flag = reserve_total_11
+					set_country_flag = reserve_total_12
+				}
+				else_if = {
+					limit = {
+						has_country_flag = reserve_total_12
+						tag = SOV
+						is_ai = yes
+					}
+					clr_country_flag = reserve_total_12
+					set_country_flag = reserve_total_13
+				}
+				else_if = {
+					limit = {
+						has_country_flag = reserve_total_13
+						tag = SOV
+						is_ai = yes
+					}
+					clr_country_flag = reserve_total_13
+					set_country_flag = reserve_total_14
+				}
+				else_if = {
+					limit = {
+						has_country_flag = reserve_total_14
+						tag = SOV
+						is_ai = yes
+					}
+					clr_country_flag = reserve_total_14
+					set_country_flag = reserve_total_15
+				}
 				else = {
 					set_country_flag = reserve_total_1
 				}
@@ -2005,6 +2052,7 @@ reserve_divisions = {
 			if = {
 				limit = {
 					original_tag = SOV
+					is_ai = no
 					NOT = { has_completed_focus = SOV_beaten_but_not_defeated }
 				}
 				has_completed_focus = SOV_emergency_powers
@@ -3793,6 +3841,7 @@ reserve_divisions = {
 			if = {
 				limit = {
 					original_tag = SOV
+					is_ai = no
 					NOT = { has_completed_focus = SOV_beaten_but_not_defeated }
 				}
 				has_completed_focus = SOV_emergency_powers
@@ -5536,6 +5585,7 @@ reserve_divisions = {
 			if = {
 				limit = {
 					original_tag = SOV
+					is_ai = no
 					NOT = { has_completed_focus = SOV_beaten_but_not_defeated }
 				}
 				has_completed_focus = SOV_emergency_powers
@@ -7302,6 +7352,7 @@ reserve_divisions = {
 			if = {
 				limit = {
 					original_tag = SOV
+					is_ai = no
 					NOT = { has_completed_focus = SOV_beaten_but_not_defeated }
 				}
 				has_completed_focus = SOV_emergency_powers
@@ -9082,6 +9133,7 @@ reserve_divisions = {
 			if = {
 				limit = {
 					original_tag = SOV
+					is_ai = no
 					NOT = { has_completed_focus = SOV_beaten_but_not_defeated }
 				}
 				has_completed_focus = SOV_emergency_powers
@@ -10818,6 +10870,7 @@ reserve_divisions = {
 			if = {
 				limit = {
 					original_tag = SOV
+					is_ai = no
 					NOT = { has_completed_focus = SOV_beaten_but_not_defeated }
 				}
 				has_completed_focus = SOV_emergency_powers

--- a/common/decisions/reserves.txt
+++ b/common/decisions/reserves.txt
@@ -2492,16 +2492,28 @@ reserve_divisions = {
 				if = {
 					limit = {
 						tag = SOV
-						OR = {
-							is_ai = no
-							NOT = { has_country_flag = infantry_template_sov }
-						}
+						is_ai = no
 					}
 					capital_scope = {
 						create_unit = {
 							division = "division_template=\"Soviet Reserve Divisíon\" start_experience_factor=0.2 start_equipment_factor=0.5 force_equipment_variants={sov_inf_1={owner=\"SOV\"}sov_hv_inf_1={owner=\"SOV\"}sov_art_1={owner=\"SOV\"}sov_hv_art_1={owner=\"SOV\"}sov_at_1={owner=\"SOV\"}}"
 							owner = ROOT
 							count = 10
+							prioritize_location = 6380
+						}
+					}
+				}
+				if = {
+					limit = {
+						tag = SOV
+						is_ai = yes
+						NOT = { has_country_flag = infantry_template_sov }
+					}
+					capital_scope = {
+						create_unit = {
+							division = "division_template=\"Soviet Reserve Divisíon\" start_experience_factor=0.2 start_equipment_factor=0.5 force_equipment_variants={sov_inf_1={owner=\"SOV\"}sov_hv_inf_1={owner=\"SOV\"}sov_art_1={owner=\"SOV\"}sov_hv_art_1={owner=\"SOV\"}sov_at_1={owner=\"SOV\"}}"
+							owner = ROOT
+							count = 15
 							prioritize_location = 6380
 						}
 					}

--- a/common/national_focus/soviet.txt
+++ b/common/national_focus/soviet.txt
@@ -4643,6 +4643,8 @@ focus_tree = {
 				}
 				else_if = {
 					limit = {
+						tag = SOV
+						is_ai = yes
 						has_country_flag = reserve_total_10
 					}
 					clr_country_flag = reserve_total_10
@@ -4650,6 +4652,8 @@ focus_tree = {
 				}
 				else_if = {
 					limit = {
+						tag = SOV
+						is_ai = yes
 						has_country_flag = reserve_total_11
 					}
 					clr_country_flag = reserve_total_11
@@ -4657,6 +4661,8 @@ focus_tree = {
 				}
 				else_if = {
 					limit = {
+						tag = SOV
+						is_ai = yes
 						has_country_flag = reserve_total_12
 					}
 					clr_country_flag = reserve_total_12
@@ -4664,6 +4670,8 @@ focus_tree = {
 				}
 				else_if = {
 					limit = {
+						tag = SOV
+						is_ai = yes
 						has_country_flag = reserve_total_13
 					}
 					clr_country_flag = reserve_total_13
@@ -4671,6 +4679,8 @@ focus_tree = {
 				}
 				else_if = {
 					limit = {
+						tag = SOV
+						is_ai = yes
 						has_country_flag = reserve_total_14
 					}
 					clr_country_flag = reserve_total_14
@@ -4678,6 +4688,8 @@ focus_tree = {
 				}
 				else_if = {
 					limit = {
+						tag = SOV
+						is_ai = yes
 						has_country_flag = reserve_total_15
 					}
 					#just dont do anything?

--- a/common/national_focus/soviet.txt
+++ b/common/national_focus/soviet.txt
@@ -4641,6 +4641,47 @@ focus_tree = {
 					clr_country_flag = reserve_total_9
 					set_country_flag = reserve_total_10
 				}
+				else_if = {
+					limit = {
+						has_country_flag = reserve_total_10
+					}
+					clr_country_flag = reserve_total_10
+					set_country_flag = reserve_total_11
+				}
+				else_if = {
+					limit = {
+						has_country_flag = reserve_total_11
+					}
+					clr_country_flag = reserve_total_11
+					set_country_flag = reserve_total_12
+				}
+				else_if = {
+					limit = {
+						has_country_flag = reserve_total_12
+					}
+					clr_country_flag = reserve_total_12
+					set_country_flag = reserve_total_13
+				}
+				else_if = {
+					limit = {
+						has_country_flag = reserve_total_13
+					}
+					clr_country_flag = reserve_total_13
+					set_country_flag = reserve_total_14
+				}
+				else_if = {
+					limit = {
+						has_country_flag = reserve_total_14
+					}
+					clr_country_flag = reserve_total_14
+					set_country_flag = reserve_total_15
+				}
+				else_if = {
+					limit = {
+						has_country_flag = reserve_total_15
+					}
+					#just dont do anything?
+				}
 				else = {
 					set_country_flag = reserve_total_1
 				}

--- a/common/national_focus/soviet.txt
+++ b/common/national_focus/soviet.txt
@@ -4643,7 +4643,13 @@ focus_tree = {
 				}
 				else_if = {
 					limit = {
-						tag = SOV
+						is_ai = no
+						has_country_flag = reserve_total_10
+					}
+					#nothing
+				}
+				else_if = {
+					limit = {
 						is_ai = yes
 						has_country_flag = reserve_total_10
 					}
@@ -4652,7 +4658,6 @@ focus_tree = {
 				}
 				else_if = {
 					limit = {
-						tag = SOV
 						is_ai = yes
 						has_country_flag = reserve_total_11
 					}
@@ -4661,7 +4666,6 @@ focus_tree = {
 				}
 				else_if = {
 					limit = {
-						tag = SOV
 						is_ai = yes
 						has_country_flag = reserve_total_12
 					}
@@ -4670,7 +4674,6 @@ focus_tree = {
 				}
 				else_if = {
 					limit = {
-						tag = SOV
 						is_ai = yes
 						has_country_flag = reserve_total_13
 					}
@@ -4679,7 +4682,6 @@ focus_tree = {
 				}
 				else_if = {
 					limit = {
-						tag = SOV
 						is_ai = yes
 						has_country_flag = reserve_total_14
 					}
@@ -4688,7 +4690,6 @@ focus_tree = {
 				}
 				else_if = {
 					limit = {
-						tag = SOV
 						is_ai = yes
 						has_country_flag = reserve_total_15
 					}


### PR DESCRIPTION
The reserve changes we made a while ago were necessary for MP as 100 reserves/other changes were needed for a human player, it is however not enough for the soviet AI.

- Increased amount of trainable reserves for the Soviet AI from 100 to 150
- Reduced the training penalty for the soviet AI during reserve recruitment from 100% to 50%
- Soviet AI does not need the Emergency power focus to deploy reserves (If the AI just started a different 70 day focus when you invade them it is enough time to utterly destroy the AI before it is even allowed to deploy any reserves)

This will obviously require further testing to find a nice balance

- [x ] Balance change (change entirely for the sake of balance purposes)
- [x ] AI change (change to any sort of AI behavior)


