### PR TITLE
Trucks and mefo bills

### DIFF
--- a/common/decisions/SOV.txt
+++ b/common/decisions/SOV.txt
@@ -19315,6 +19315,42 @@ SOV_industry_relocation = {
 }
 
 war_measures = {
+	SOV_AI_trucks_are_scuffed = { #thank you pdx
+		icon = generic_prepare_civil_war
+
+		allowed = {
+			original_tag = SOV
+		}
+
+		available = {
+			original_tag = SOV
+			is_ai = yes
+			has_war = yes
+			has_completed_focus = SOV_emergency_powers
+			NOT = { has_war_with = USA }
+		}
+		visible = {
+			original_tag = SOV
+			is_ai = yes
+		}
+		cost = 0
+
+		fire_only_once = no
+
+		days_re_enable = 90
+
+		ai_will_do = {
+			factor = 320
+		}
+
+		complete_effect = {
+			add_equipment_to_stockpile = {
+				type = USA_motorized_equipment_1
+				producer = USA
+				amount = 3000
+			}
+		}
+	}
 	SOV_forced_conscription = {
 		priority = 100
 

--- a/common/decisions/SOV.txt
+++ b/common/decisions/SOV.txt
@@ -19347,7 +19347,7 @@ war_measures = {
 			add_equipment_to_stockpile = {
 				type = USA_motorized_equipment_1
 				producer = USA
-				amount = 3000
+				amount = 2500
 			}
 		}
 	}

--- a/common/decisions/SOV.txt
+++ b/common/decisions/SOV.txt
@@ -19347,7 +19347,7 @@ war_measures = {
 			add_equipment_to_stockpile = {
 				type = USA_motorized_equipment_1
 				producer = USA
-				amount = 2500
+				amount = 5000
 			}
 		}
 	}

--- a/common/decisions/SOV.txt
+++ b/common/decisions/SOV.txt
@@ -19330,6 +19330,9 @@ war_measures = {
 			NOT = { has_war_with = USA }
 		}
 		visible = {
+			USA = {
+				is_ai = yes
+			}
 			original_tag = SOV
 			is_ai = yes
 		}

--- a/events/WTT_Germany.txt
+++ b/events/WTT_Germany.txt
@@ -2956,7 +2956,8 @@ country_event = {
 	}
 	option = {
 		name = wtt_germany.62.b
-		add_stability = -0.25
+		add_stability = -0.30
+		clr_country_flag = mefo_bills_removed_through_war
 	}
 }
 

--- a/events/wa_sov_events.txt
+++ b/events/wa_sov_events.txt
@@ -7086,6 +7086,29 @@ country_event = {
 }
 
 country_event = {
+	id = sov_armor.927
+	hidden = yes
+
+	mean_time_to_happen = { days = 1 }
+
+	fire_only_once = yes
+
+	trigger = {
+		date > 1942.1.1
+		tag = SOV
+		is_ai = yes
+		has_war = yes
+	}
+
+	immediate = {
+		add_political_power = 1500
+	}
+
+	option = {}
+
+}
+
+country_event = {
 	id = sov_armor.237
 	hidden = yes
 


### PR DESCRIPTION
- Fixes the bug where the mefo bill event fires over and over again

- Added a decision for the Sov AI similiar to the convoy decision for the US, (adds 5000 trucks every 90 days)

- SOV AI gets more pp through an event (apparently it uses up 2000 in less than 6 months and then cant take any decisions in 1942)

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] AI change (change to any sort of AI behavior)




- [x] I HAVE TESTED THESE CHANGES BY RUNNING THE GAME AND VERIFYING THEY WORK AS INTENDED.

