### PR TITLE
AI

### DIFF
--- a/common/ai_strategy/SOV.txt
+++ b/common/ai_strategy/SOV.txt
@@ -230,15 +230,16 @@ SOV_produce_more_mbts = {
 SOV_stopspamming = {
 	enable = {
 		original_tag = SOV
-		has_equipment = { support_equipment > 24999 }
+		has_equipment = {
+			support_equipment > 24999
+		}
 		NOT =  {
 			has_global_flag = soviet_union_defeated
 		}
 	}
-	abort = {
-		has_equipment = { support_equipment < 24999 }
-	}
-	
+
+	abort_when_not_enabled = yes
+
 	ai_strategy = {
 		type = equipment_variant_production_factor
 		id = support_equipment
@@ -254,7 +255,7 @@ SOV_moreaa = {
 	abort = {
 		always = no
 	}
-	
+
 	ai_strategy = {
 		type = equipment_variant_production_factor
 		id = anti_air_equipment
@@ -276,7 +277,7 @@ SOV_lesst26 = {
 	abort = {
 		date < 1940.3.1
 	}
-	
+
 	ai_strategy = {
 		type = equipment_variant_production_factor
 		id = light_tank_chassis

--- a/common/ai_strategy/USA.txt
+++ b/common/ai_strategy/USA.txt
@@ -4706,6 +4706,19 @@ USA_GER_ROM_BUL_HUN_stay_out_of_shitholes = {
 		area = middle_east
 		value = -200
 	}
+	
+	ai_strategy = {
+		type = front_unit_request
+
+		area = east_asia
+		value = -200
+	}
+	
+	ai_strategy = {
+		type = dont_defend_ally_borders
+		id = "FRV"
+		value = 500
+	}
 }
 
 

--- a/common/ai_strategy_plans/SOV_historical_strategy_plan.txt
+++ b/common/ai_strategy_plans/SOV_historical_strategy_plan.txt
@@ -131,6 +131,10 @@ SOV_historical_plan = {
 		SOV_advanced_maneuvers
 		SOV_experts_in_camouflage
 		SOV_form_the_stavka
+		SOV_deep_battle
+		SOV_intensify_pilot_training_program
+		SOV_perfecting_the_infantry_corps
+		SOV_perfecting_the_armour_corps
 		SOV_the_collectivization_process
 		SOV_pc_of_mortar_armament # -> Nov 1941
 		SOV_superior_war_machines
@@ -140,14 +144,10 @@ SOV_historical_plan = {
 		SOV_the_molotov_line
 		SOV_impregnable_forts
 		SOV_protect_the_white_sea_baltic_canal
-		SOV_perfecting_the_infantry_corps
-		SOV_perfecting_the_armour_corps
-		SOV_deep_battle
 		SOV_assault_artillery
 		SOV_guards_mortars
 		SOV_guards_units
 		SOV_the_glory_of_the_red_army
-		SOV_intensify_pilot_training_program
 		SOV_increase_aircraft_production
 		SOV_smersh
 		SOV_the_road_of_life #35

--- a/common/ai_strategy_plans/SOV_historical_strategy_plan.txt
+++ b/common/ai_strategy_plans/SOV_historical_strategy_plan.txt
@@ -27,6 +27,9 @@ SOV_historical_plan = {
 
 	ai_national_focuses = {
 		#Things to do ASAP
+		SOV_mol_rib_pact
+		SOV_claims_in_baltic
+		SOV_secure_leningrad
 		SOV_lay_the_foundations_of_retribution
 		SOV_lessons_of_war
 		SOV_disband_the_cavalry_army_clique
@@ -38,90 +41,85 @@ SOV_historical_plan = {
 		SOV_tankograd
 		SOV_peoples_militia
 		SOV_soviet_artillery
+		SOV_smersh
+		SOV_barrier_troops
+		SOV_the_road_of_life
 
 		#1936
+		SOV_addressing_internal_affairs
+		SOV_the_path_of_marxism_leninism
+		SOV_the_centre
+		SOV_the_stalin_constitution
+		SOV_nkvd_primacy
 		SOV_connection_of_the_interior
-		SOV_workers_culture
-		SOV_evolve_our_urban_centres
-		SOV_gaz_automobile_plants
-		SOV_finish_the_second_five_year_plan
-		SOV_the_path_of_marxism_leninism #35
-		SOV_the_centre #35
-		SOV_great_purge
-		SOV_the_zinovyevite_terrorist_center #35
 		SOV_eyes_to_the_west
 		SOV_send_military_advisors_to_spain
+		SOV_workers_culture
+		SOV_great_purge
+		SOV_evolve_our_urban_centres
+		SOV_gaz_automobile_plants
+		SOV_the_zinovyevite_terrorist_center
+		SOV_finish_the_second_five_year_plan
 
 		#1937
-		SOV_the_stalin_constitution
 		SOV_start_the_third_five_year_plan
 		SOV_lower_workers_minimum_wage
-		SOV_the_anti_soviet_trotskyist_center #35
+		SOV_the_anti_soviet_trotskyist_center
 		SOV_secure_the_administration
-		SOV_addressing_internal_affairs #35
-		SOV_nkvd_primacy
 		SOV_mining_infrastructure_investment
-		SOV_urbanise_the_urals #35
-		SOV_found_the_pcdi #35
-		SOV_strengthen_the_mobilization_plan #35
-		SOV_cohesion_first #35
-		SOV_eyes_to_the_east
+		SOV_urbanise_the_urals
+		SOV_bread_basket_of_the_soviet_union
+		SOV_militarized_schools
+		SOV_socialist_realism
+		SOV_expand_the_agitprop
+		SOV_collectivist_propaganda
+		SOV_new_soviet_society
+		#SOV_eyes_to_the_east
 
 		#1938
 		SOV_the_workers_dictatorship
-		SOV_pc_of_mechanical_engineering #35
-		SOV_transpolar_flights #35
-		SOV_the_military_conspiracy #35
-		SOV_socialism_in_one_country #35
-		SOV_the_bloc_of_rights_and_trotskyites #35 -> Early 1938
-		SOV_the_threat_from_the_land_of_the_rising_sun #35
-		SOV_expand_the_agitprop #35
-		SOV_national_specialists #35
-		SOV_planned_economy
+		SOV_the_military_conspiracy
+		SOV_socialism_in_one_country
+		SOV_the_collectivization_process
+		SOV_found_the_pcdi
+		SOV_the_ussr_academy_of_sciences
+		SOV_strengthen_the_mobilization_plan
+		SOV_cohesion_first
+		SOV_rehabilitated_military
+		SOV_pc_of_mechanical_engineering
+		SOV_transpolar_flights
+		SOV_the_bloc_of_rights_and_trotskyites
+		#SOV_the_threat_from_the_land_of_the_rising_sun
+		SOV_national_specialists
 		SOV_socialist_science
 		SOV_progress_cult
 
 		#1939
 		SOV_assert_soviet_naval_presence #35
-		SOV_operation_zet #35
-		SOV_the_ussr_academy_of_sciences
 		SOV_military_engineering_university #35
 		SOV_utilization_of_the_tulan_Arms_industry
 		SOV_modernization_of_the_red_army
 		SOV_development_of_the_shock_army
-		SOV_bread_basket_of_the_soviet_union
 		SOV_policy_of_individual_security # 35 -> May 1939
 		SOV_foster_flying_clubs
 		SOV_national_academies_of_sciences #35
-		SOV_collectivist_propaganda
-		SOV_socialist_realism
-		SOV_militarized_schools
-		SOV_new_soviet_society
 		SOV_merge_tank_and_materiel_plants
-		SOV_mol_rib_pact #
 		SOV_revitalise_the_airforce
 		SOV_stalins_cult_of_personality #35
-		SOV_claims_in_baltic #35
-		SOV_secure_leningrad
 		SOV_claims_on_poland
 		SOV_demand_eastern_poland # (IN CASE NO MOLOTOV-RIBENTROP)
 		SOV_claim_on_bessarabia # -> Jul 1940
 		SOV_evolution_of_the_air_strategy
 		SOV_behead_the_snake #35 -> May 1940 (raid)
+		SOV_intensify_pilot_training_program
 
 		#1940
-		SOV_rehabilitated_military
 		SOV_military_reorganization
 		SOV_expand_the_aircraft_industry
 		SOV_merge_aircraft_plants
 		SOV_expand_aviation_institutes
 		SOV_ground_support
-		SOV_positive_heroism
 		SOV_assert_soviet_naval_presence
-		SOV_closed_city_network
-		SOV_steel_casting_industry
-		SOV_oil_production
-		SOV_synthetic_rubber_programme
 		SOV_improve_the_stalin_line
 		SOV_keep_commissars_organization
 		SOV_reinforce_southern_naval_bases
@@ -129,16 +127,21 @@ SOV_historical_plan = {
 		SOV_surface_warfare
 		SOV_an_oceangoing_navy
 		SOV_advanced_maneuvers
-		SOV_experts_in_camouflage
 		SOV_form_the_stavka
+		SOV_experts_in_camouflage
 		SOV_deep_battle
-		SOV_intensify_pilot_training_program
 		SOV_perfecting_the_infantry_corps
 		SOV_perfecting_the_armour_corps
-		SOV_the_collectivization_process
+		SOV_increase_aircraft_production
+		SOV_positive_heroism
 		SOV_pc_of_mortar_armament # -> Nov 1941
 		SOV_superior_war_machines
 		SOV_women_in_aviation
+		SOV_steel_casting_industry
+		SOV_oil_production
+		SOV_synthetic_rubber_programme
+		SOV_closed_city_network
+		
 
 
 		SOV_the_molotov_line
@@ -148,9 +151,6 @@ SOV_historical_plan = {
 		SOV_guards_mortars
 		SOV_guards_units
 		SOV_the_glory_of_the_red_army
-		SOV_increase_aircraft_production
-		SOV_smersh
-		SOV_the_road_of_life #35
 
 
 		#1942
@@ -168,7 +168,6 @@ SOV_historical_plan = {
 		SOV_war_heroes
 		SOV_swap_to_political_advisors
 		SOV_the_komsomol #35
-		SOV_barrier_troops #35
 		SOV_development_aid_for_eastern_allies #35
 		SOV_patriarch_of_all_russia #35
 		SOV_annex_tannu_tuva #35 -> Nov 1944

--- a/common/ai_strategy_plans/SOV_historical_strategy_plan.txt
+++ b/common/ai_strategy_plans/SOV_historical_strategy_plan.txt
@@ -44,6 +44,7 @@ SOV_historical_plan = {
 		SOV_smersh
 		SOV_barrier_troops
 		SOV_the_road_of_life
+		SOV_organization_of_the_partisans
 
 		#1936
 		SOV_addressing_internal_affairs
@@ -161,7 +162,6 @@ SOV_historical_plan = {
 		SOV_penal_battalions #35 -> 1942+
 
 		#1943 -----------> -0.5y (Compensated by the ASAP stuff)
-		SOV_organization_of_the_partisans
 		SOV_revive_the_stakhanovite_movement #35
 
 		#1944

--- a/common/decisions/ENG.txt
+++ b/common/decisions/ENG.txt
@@ -4542,7 +4542,10 @@ operations = {
 		}
 
 		available = {
-			has_country_leader = { ruling_only = yes name = "Winston Churchill" }
+			OR = {
+				has_country_leader = { ruling_only = yes name = "Winston Churchill" }
+				has_country_leader = { ruling_only = yes name = "George VI" }
+			}
 			has_government = democratic
 			has_completed_focus = ENG_local_intervention
 			has_war_with = GER
@@ -4562,7 +4565,10 @@ operations = {
 		}
 
 		visible = {
-			has_country_leader = { ruling_only = yes name = "Winston Churchill" }
+			OR = {
+				has_country_leader = { ruling_only = yes name = "Winston Churchill" }
+				has_country_leader = { ruling_only = yes name = "George VI" }
+			}
 			tag = ENG
 			has_government = democratic
 			has_war_with = GER

--- a/common/decisions/ENG.txt
+++ b/common/decisions/ENG.txt
@@ -4344,6 +4344,79 @@ war_measures = {
 			}
 		}
 	}
+	
+	####################################Lendlease soviets ai --> ai
+	
+	ENG_provide_fighterplanes_ai = {
+
+		icon = generic_industry
+
+		allowed = {
+			original_tag = ENG
+		}
+
+		visible = {
+			SOV = {
+				is_ai = yes
+			}
+			is_ai = yes
+			SOV = { has_war_with = GER }
+			date > 1944.6.1
+		}
+
+		available = {
+			SOV = {
+				is_ai = yes
+				has_deployed_air_force_size = { size < 5500 type = fighter }
+			}
+			date > 1944.6.1
+			is_ai = yes
+			original_tag = ENG
+			SOV = { has_war_with = GER }
+			NOT = { SOV = { has_war_with = ENG } }
+			OR = {
+				has_government = democratic
+				SOV = { has_government = ROOT }
+				is_in_faction_with = SOV
+			}
+		}
+
+        days_re_enable = 60
+
+        modifier = {
+			civilian_factory_use = 10
+        }
+
+		cost = 0
+		days_remove = 30
+
+		ai_will_do = {
+			factor = 400
+		}
+
+		complete_effect = {
+		}
+
+		remove_effect = {
+			SOV = {
+				if = {
+					limit = {
+						ENG = { has_tech = eng_fighter_6 }
+					}
+					add_equipment_to_stockpile = { type = eng_fighter_equipment_7 amount = 200 producer = ENG }
+				}
+				else_if = {
+					limit = {
+						ENG = { has_tech = eng_fighter_5 }
+					}
+					add_equipment_to_stockpile = { type = eng_fighter_equipment_6 amount = 200 producer = ENG }
+				}
+				else = {
+					add_equipment_to_stockpile = { type = eng_fighter_equipment_5 amount = 200 producer = ENG }
+				}
+			}
+		}
+	}
 }
 
 operations = {

--- a/common/decisions/SOV.txt
+++ b/common/decisions/SOV.txt
@@ -19385,7 +19385,7 @@ war_measures = {
 				has_country_flag = reserve_total_10
 			}
 			has_war = yes
-			num_divisions < 200
+			num_divisions < 210
 		}
 
 		cost = 0
@@ -19481,7 +19481,7 @@ war_measures = {
 			has_war = yes
 			is_ai = yes
 			has_war = yes
-			num_divisions < 250
+			num_divisions < 300
 			653 = {
 				CONTROLLER = {
 					OR = {

--- a/common/decisions/SOV.txt
+++ b/common/decisions/SOV.txt
@@ -19553,7 +19553,7 @@ war_measures = {
 				}
 				capital_scope = {
 					create_unit = {
-						division = "division_template = \"Soviet Heavy Tank Division\" start_experience_factor = 0.2 start_equipment_factor=0.8"
+						division = "division_template = \"Soviet Adv Heavy Tank Division\" start_experience_factor = 0.2 start_equipment_factor=0.8"
 						owner = SOV
 						count = 1
 						prioritize_location = 1808

--- a/common/decisions/SOV.txt
+++ b/common/decisions/SOV.txt
@@ -19460,6 +19460,121 @@ war_measures = {
 			}
 		}
 	}
+	SOV_uralvagonzavod = {
+		priority = 100
+
+		icon = generic_political_discourse
+
+		ai_will_do = {
+			base = 1
+		}
+
+		allowed = {
+			original_tag = SOV
+		}
+
+		available = {
+			GER = {
+				is_ai = no
+			}
+			has_completed_focus = SOV_emergency_powers
+			has_war = yes
+			is_ai = yes
+			has_war = yes
+			num_divisions < 250
+			653 = {
+				CONTROLLER = {
+					OR = {
+						tag = SOV
+						is_in_faction_with = SOV
+						is_subject_of = SOV
+					}
+				}
+			}
+			653 = {
+				non_damaged_building_level = {
+					building = arms_factory
+					level > 14
+				}
+			}
+		}
+
+		cost = 0
+
+		visible = {
+			has_completed_focus = SOV_emergency_powers
+			has_war = yes
+			is_ai = yes
+		}
+
+		cancel_if_not_visible = yes
+
+		days_remove = 20
+		is_good = yes
+		cost = 0
+
+		ai_will_do = {
+			factor = 800
+		}
+
+		remove_effect = {
+			add_manpower = -16800
+			if = {
+				limit = {
+					date < 1943.7.1
+				}
+				capital_scope = {
+					create_unit = {
+						division = "division_template = \"Soviet Early Medium Tank Division\" start_experience_factor = 0.2 start_equipment_factor=0.8"
+						owner = SOV
+						count = 1
+						prioritize_location = 1808
+					}
+				}
+			}
+			if = {
+				limit = {
+					date > 1943.7.1
+					date < 1944.1.1
+				}
+				capital_scope = {
+					create_unit = {
+						division = "division_template = \"Soviet Adv Medium Tank Division\" start_experience_factor = 0.2 start_equipment_factor=0.8"
+						owner = SOV
+						count = 1
+						prioritize_location = 1808
+					}
+				}
+			}
+			if = {
+				limit = {
+					date > 1944.1.1
+					date < 1945.7.1
+				}
+				capital_scope = {
+					create_unit = {
+						division = "division_template = \"Soviet Adv Heavy Tank Division\" start_experience_factor = 0.2 start_equipment_factor=0.8"
+						owner = SOV
+						count = 1
+						prioritize_location = 1808
+					}
+				}
+			}
+			if = {
+				limit = {
+					date > 1945.7.1
+				}
+				capital_scope = {
+					create_unit = {
+						division = "division_template = \"Soviet Modern Tank Division\" start_experience_factor = 0.2 start_equipment_factor=0.9"
+						owner = SOV
+						count = 2
+						prioritize_location = 1808
+					}
+				}
+			}
+		}
+	}
 	SOV_relocate_capital_from_moscow = {
 		icon = generic_operation
 		available = {

--- a/common/decisions/SOV.txt
+++ b/common/decisions/SOV.txt
@@ -19553,7 +19553,7 @@ war_measures = {
 				}
 				capital_scope = {
 					create_unit = {
-						division = "division_template = \"Soviet Adv Heavy Tank Division\" start_experience_factor = 0.2 start_equipment_factor=0.8"
+						division = "division_template = \"Soviet Heavy Tank Division\" start_experience_factor = 0.2 start_equipment_factor=0.8"
 						owner = SOV
 						count = 1
 						prioritize_location = 1808

--- a/common/decisions/SOV.txt
+++ b/common/decisions/SOV.txt
@@ -19553,7 +19553,7 @@ war_measures = {
 				}
 				capital_scope = {
 					create_unit = {
-						division = "division_template = \"Soviet Adv Heavy Tank Division\" start_experience_factor = 0.2 start_equipment_factor=0.8"
+						division = "division_template = \"Soviet Heavy Tank Division\" start_experience_factor = 0.2 start_equipment_factor=0.8"
 						owner = SOV
 						count = 1
 						prioritize_location = 1808
@@ -20728,6 +20728,79 @@ SOV_military_reform = {
 
 		visible = {
 			NOT = { has_country_flag = SOV_air_reform_2 }
+			is_ai = no
+		}
+
+		cost = 0
+		ai_will_do = {
+			factor = 500
+		}
+		days_remove = 30
+
+		remove_effect = {
+			if = {
+				limit = {
+					NOT = { has_country_flag = SOV_air_reform_1 }
+				}
+				set_country_flag = SOV_air_reform_1
+				add_to_variable = { SOV_soviet_airforce_air_mission_xp_gain_factor = 0.3 }
+				add_to_variable = { SOV_soviet_airforce_air_doctrine_cost_factor = -0.5 }
+				add_to_variable = { SOV_soviet_airforce_air_agility_factor = 0.1 }
+				add_to_variable = { SOV_soviet_airforce_air_attack_factor = 0.1 }
+				add_to_variable = { SOV_soviet_airforce_air_cas_present_factor = 0.1 }
+				custom_effect_tooltip = SOV_air_reform_1_tt
+			}
+			else = {
+				set_country_flag = SOV_air_reform_2
+				add_to_variable = { SOV_soviet_airforce_air_mission_xp_gain_factor = 0.4 }
+				add_to_variable = { SOV_soviet_airforce_air_doctrine_cost_factor = -0.5 }
+				add_to_variable = { SOV_soviet_airforce_air_agility_factor = 0.2 }
+				add_to_variable = { SOV_soviet_airforce_air_attack_factor = 0.2 }
+				add_to_variable = { SOV_soviet_airforce_air_cas_present_factor = 0.2 }
+				custom_effect_tooltip = SOV_air_reform_2_tt
+			}
+		}
+		complete_effect = {
+			air_experience = -200
+		}
+	}
+	
+	SOV_air_reform_ai = { #Ai will do modifiers dont work on doctrines, soviet AI is incapable of reforming its airforce
+
+		icon = generic_prepare_civil_war
+
+		available = {
+			tag = SOV
+			is_ai = yes
+			has_completed_focus = SOV_evolution_of_the_air_strategy
+			OR = {
+				AND = {
+					NOT = { has_country_flag = SOV_air_reform_1 }
+					date > 1941.8.1
+				}
+				AND = {
+					has_country_flag = SOV_air_reform_1
+					date > 1942.1.1
+					custom_trigger_tooltip = {
+						tooltip = SOV_has_not_officers_purged_tt
+						NOT = { has_idea = officers_purged }
+						NOT = { has_idea = officers_purged_2 }
+						NOT = { has_idea = officers_purged_3 }
+						NOT = { has_idea = officers_purged_4 }
+						NOT = { has_idea = officers_purged_5 }
+						NOT = { has_idea = officers_purged_6 }
+						NOT = { has_idea = officers_purged_7 }
+						NOT = { has_idea = officers_purged_8 }
+						NOT = { has_idea = officers_purged_9 }
+						NOT = { has_idea = officers_purged_10 }
+					}
+				}
+			}
+		}
+
+		visible = {
+			NOT = { has_country_flag = SOV_air_reform_2 }
+			is_ai = yes
 		}
 
 		cost = 0

--- a/common/decisions/SOV.txt
+++ b/common/decisions/SOV.txt
@@ -19350,7 +19350,7 @@ war_measures = {
 			add_equipment_to_stockpile = {
 				type = USA_motorized_equipment_1
 				producer = USA
-				amount = 5000
+				amount = 6500
 			}
 		}
 	}
@@ -19449,13 +19449,77 @@ war_measures = {
 						anti_air = { x = 1 y = 2 }
 					}
 				}
+				division_template = {
+					name = "Mekhanizirovanaya Diviziya"
+					division_names_group = SOV_MEC_01
+					is_locked = yes
+
+					regiments = {
+						mechanized = { x = 0 y = 0 }
+						mechanized = { x = 0 y = 1 }
+						mechanized = { x = 0 y = 2 }
+						mechanized = { x = 0 y = 3 }
+
+						mechanized = { x = 1 y = 0 }
+						mechanized = { x = 1 y = 1 }
+						mechanized = { x = 1 y = 2 }
+						mechanized = { x = 1 y = 3 }
+
+						mechanized = { x = 2 y = 0 }
+						mechanized = { x = 2 y = 1 }
+						mechanized = { x = 2 y = 2 }
+						mechanized = { x = 2 y = 3 }
+
+						mechanized = { x = 3 y = 0 }
+						mechanized = { x = 3 y = 1 }
+						mechanized = { x = 3 y = 2 }
+						mechanized = { x = 3 y = 3 }
+						
+						motorized_heavy_anti_tank_brigade = { x = 4 y = 0 }
+						motorized_heavy_anti_tank_brigade = { x = 4 y = 1 }
+						motorized_heavy_anti_tank_brigade = { x = 4 y = 2 }
+						motorized_heavy_anti_tank_brigade = { x = 4 y = 3 }
+
+					}
+					support = {
+						engineer = { x = 0 y = 0 }
+						heavy_artillery = { x = 0 y = 1 }
+						horse_logistics_company = { x = 0 y = 2 }
+						signal_company = { x = 0 y = 3 }
+						heavy_assault = { x = 0 y = 4 }
+
+						armoured_recon = { x = 1 y = 0 }
+						field_hospital = { x = 1 y = 1 }
+						heavy_anti_air = { x = 1 y = 2 }
+						heavy_anti_tank = { x = 1 y = 3 }
+						motorized_rocket = { x = 1 y = 4 }
+					}
+				}
 			}
-			capital_scope = {
-				create_unit = {
-					division = "division_template = \"Rifle Division\" start_experience_factor = 0.2 start_equipment_factor=0.75"
-					owner = SOV
-					count = 12
-					prioritize_location = 6380
+			if = {
+				limit = {
+					date < 1944.11.1
+				}
+				capital_scope = {
+					create_unit = {
+						division = "division_template = \"Rifle Division\" start_experience_factor = 0.2 start_equipment_factor=0.75"
+						owner = SOV
+						count = 12
+						prioritize_location = 6380
+					}
+				}
+			}
+			if = {
+				limit = {
+					date > 1944.11.1
+				}
+				capital_scope = {
+					create_unit = {
+						division = "division_template = \"Mekhanizirovanaya Diviziya\" start_experience_factor = 0.25 start_equipment_factor=1.0 force_equipment_variants={usa_mechanized_equipment_3={owner=\"USA\"}usa_hv_inf_7={owner=\"USA\"}usa_inf_5={owner=\"USA\"}usa_hv_aa_3={owner=\"USA\"}usa_hv_aa_3={owner=\"USA\"}}"
+						owner = SOV
+						count = 8
+						prioritize_location = 6380
+					}
 				}
 			}
 		}
@@ -19566,7 +19630,7 @@ war_measures = {
 				}
 				capital_scope = {
 					create_unit = {
-						division = "division_template = \"Soviet Modern Tank Division\" start_experience_factor = 0.2 start_equipment_factor=0.9"
+						division = "division_template = \"Soviet Modern Heavy Tank Division\" start_experience_factor = 0.2 start_equipment_factor=0.95"
 						owner = SOV
 						count = 2
 						prioritize_location = 1808

--- a/common/decisions/SOV.txt
+++ b/common/decisions/SOV.txt
@@ -19354,6 +19354,46 @@ war_measures = {
 			}
 		}
 	}
+	SOV_AI_armyspirit = { #army has been reformed
+		icon = generic_prepare_civil_war
+
+		allowed = {
+			original_tag = SOV
+		}
+
+		available = {
+			date > 1942.6.1
+			original_tag = SOV
+			is_ai = yes
+		}
+		visible = {
+			has_tech = large_front_operations
+			has_tech = armoured_waves
+			OR = {
+				has_tech = artillery_overwatch
+				has_tech = long_range_combat
+				has_tech = battlefield_brawler
+				has_tech = orders_by_task
+				has_tech = orders_by_directive
+			}
+			date > 1942.6.1
+			original_tag = SOV
+			is_ai = yes
+		}
+		cost = 0
+
+		fire_only_once = yes
+
+		ai_will_do = {
+			factor = 320
+		}
+
+		complete_effect = {
+			set_country_flag = army_is_reformed
+			add_ideas = logistical_focus_spirit
+			add_ideas = grand_battleplan_army_spirit
+		}
+	}
 	SOV_forced_conscription = {
 		priority = 100
 

--- a/common/decisions/SOV_factions.txt
+++ b/common/decisions/SOV_factions.txt
@@ -849,12 +849,12 @@ SOV_internal_factions = {
 		}
 
 		ai_will_do = {
-			factor = 10
+			factor = 40
 
 			modifier = {
 				factor = 0
 
-				date < 1940.1.1
+				date < 1939.1.1
 			}
 		}
 

--- a/common/decisions/USA.txt
+++ b/common/decisions/USA.txt
@@ -4321,6 +4321,626 @@ USA_aid_soviet_union = {
 			}
 		}
 	}
+	
+	######### Lend Lease (AI > AI)
+	
+	USA_provide_support_equipment_ai = {
+
+		icon = generic_industry
+
+		allowed = {
+			original_tag = USA
+		}
+
+		visible = {
+			SOV = {
+				is_ai = yes
+			}
+			is_ai = yes
+			has_completed_focus = USA_lend_lease_act
+			SOV = { has_war_with = GER }
+			date > 1942.1.1
+		}
+
+		available = {
+			SOV = {
+				is_ai = yes
+				has_equipment = { support_equipment < 1 }
+			}
+			date > 1942.1.1
+			is_ai = yes
+			has_equipment = { support_equipment > 19999 }
+			original_tag = USA
+			has_completed_focus = USA_lend_lease_act
+			SOV = { has_war_with = GER }
+			NOT = { SOV = { has_war_with = USA } }
+			OR = {
+				has_government = democratic
+				SOV = { has_government = ROOT }
+				is_in_faction_with = SOV
+			}
+		}
+
+        days_re_enable = 60
+
+        modifier = {
+			civilian_factory_use = 10
+        }
+
+		cost = 0
+		days_remove = 30
+
+		ai_will_do = {
+			factor = 400
+		}
+
+		complete_effect = {
+		}
+
+		remove_effect = {
+			add_equipment_to_stockpile = {
+				type = support_equipment_1
+				producer = USA
+				amount = -10000
+			}
+			SOV = {
+				add_equipment_to_stockpile = {
+					type = support_equipment_1
+					producer = USA
+					amount = 10000
+				}
+			}
+		}
+	}
+	
+	USA_provide_guns_ai = {
+
+		icon = generic_industry
+
+		allowed = {
+			original_tag = USA
+		}
+
+		visible = {
+			SOV = {
+				is_ai = yes
+			}
+			is_ai = yes
+			has_completed_focus = USA_lend_lease_act
+			SOV = { has_war_with = GER }
+			date > 1942.1.1
+		}
+
+		available = {
+			SOV = {
+				is_ai = yes
+				has_equipment = { heavy_infantry_equipment < 1 }
+			}
+			date > 1942.1.1
+			is_ai = yes
+			has_equipment = { heavy_infantry_equipment > 19999 }
+			original_tag = USA
+			has_completed_focus = USA_lend_lease_act
+			SOV = { has_war_with = GER }
+			NOT = { SOV = { has_war_with = USA } }
+			OR = {
+				has_government = democratic
+				SOV = { has_government = ROOT }
+				is_in_faction_with = SOV
+			}
+		}
+
+        days_re_enable = 60
+
+        modifier = {
+			civilian_factory_use = 10
+        }
+
+		cost = 0
+		days_remove = 30
+
+		ai_will_do = {
+			factor = 400
+		}
+
+		complete_effect = {
+		}
+
+		remove_effect = {
+			add_equipment_to_stockpile = {
+				type = heavy_infantry_equipment
+				producer = USA
+				amount = -15000
+			}
+			SOV = {
+				if = {
+					limit = {
+						USA = { has_tech = usa_heavy_infantry_weapons_8 }
+					}
+					add_equipment_to_stockpile = { type = usa_hv_inf_8 amount = 15000 producer = USA }
+				}
+				else_if = {
+					limit = {
+						USA = { has_tech = usa_heavy_infantry_weapons_7 }
+					}
+					add_equipment_to_stockpile = { type = usa_hv_inf_7 amount = 15000 producer = USA }
+				}
+				else_if = {
+					limit = {
+						USA = { has_tech = usa_heavy_infantry_weapons_6 }
+					}
+					add_equipment_to_stockpile = { type = usa_hv_inf_6 amount = 15000 producer = USA }
+				}
+				else_if = {
+					limit = {
+						USA = { has_tech = usa_heavy_infantry_weapons_5 }
+					}
+					add_equipment_to_stockpile = { type = usa_hv_inf_5 amount = 15000 producer = USA }
+				}
+				else_if = {
+					limit = {
+						USA = { has_tech = usa_heavy_infantry_weapons_4 }
+					}
+					add_equipment_to_stockpile = { type = usa_hv_inf_4 amount = 15000 producer = USA }
+				}
+				else_if = {
+					limit = {
+						USA = { has_tech = usa_heavy_infantry_weapons_3 }
+					}
+					add_equipment_to_stockpile = { type = usa_hv_inf_3 amount = 15000 producer = USA }
+				}
+				else_if = {
+					limit = {
+						USA = { has_tech = usa_heavy_infantry_weapons_2 }
+					}
+					add_equipment_to_stockpile = { type = usa_hv_inf_2 amount = 15000 producer = USA }
+				}
+				else = {
+					add_equipment_to_stockpile = { type = usa_hv_inf_1 amount = 15000 producer = USA }
+				}
+			}
+		}
+	}
+	
+	USA_provide_artillery_ai = {
+
+		icon = generic_industry
+
+		allowed = {
+			original_tag = USA
+		}
+
+		visible = {
+			SOV = {
+				is_ai = yes
+			}
+			is_ai = yes
+			has_completed_focus = USA_lend_lease_act
+			SOV = { has_war_with = GER }
+			date > 1942.1.1
+		}
+
+		available = {
+			SOV = {
+				is_ai = yes
+				has_equipment = { artillery_equipment < 1 }
+			}
+			date > 1942.1.1
+			is_ai = yes
+			has_equipment = { artillery_equipment > 2999 }
+			original_tag = USA
+			has_completed_focus = USA_lend_lease_act
+			SOV = { has_war_with = GER }
+			NOT = { SOV = { has_war_with = USA } }
+			OR = {
+				has_government = democratic
+				SOV = { has_government = ROOT }
+				is_in_faction_with = SOV
+			}
+		}
+
+        days_re_enable = 60
+
+        modifier = {
+			civilian_factory_use = 10
+        }
+
+		cost = 0
+		days_remove = 30
+
+		ai_will_do = {
+			factor = 400
+		}
+
+		complete_effect = {
+		}
+
+		remove_effect = {
+			add_equipment_to_stockpile = {
+				type = artillery_equipment
+				producer = USA
+				amount = -2000
+			}
+			SOV = {
+				if = {
+					limit = {
+						USA = { has_tech = usa_artillery_4 }
+					}
+					add_equipment_to_stockpile = { type = usa_art_4 amount = 2000 producer = USA }
+				}
+				else_if = {
+					limit = {
+						USA = { has_tech = usa_artillery_3 }
+					}
+					add_equipment_to_stockpile = { type = usa_art_3 amount = 2000 producer = USA }
+				}
+				else_if = {
+					limit = {
+						USA = { has_tech = usa_artillery_2 }
+					}
+					add_equipment_to_stockpile = { type = usa_art_2 amount = 2000 producer = USA }
+				}
+				else = {
+					add_equipment_to_stockpile = { type = usa_art_1 amount = 2000 producer = USA }
+				}
+			}
+		}
+	}
+	
+	USA_provide_mechanized_ai = {
+
+		icon = generic_industry
+
+		allowed = {
+			original_tag = USA
+		}
+
+		visible = {
+			SOV = {
+				is_ai = yes
+			}
+			is_ai = yes
+			has_completed_focus = USA_lend_lease_act
+			SOV = { has_war_with = GER }
+			date > 1942.1.1
+		}
+
+		available = {
+			SOV = {
+				is_ai = yes
+				has_equipment = { mechanized_equipment < 1 }
+			}
+			date > 1942.1.1
+			is_ai = yes
+			has_equipment = { mechanized_equipment > 2999 }
+			original_tag = USA
+			has_completed_focus = USA_lend_lease_act
+			SOV = { has_war_with = GER }
+			NOT = { SOV = { has_war_with = USA } }
+			OR = {
+				has_government = democratic
+				SOV = { has_government = ROOT }
+				is_in_faction_with = SOV
+			}
+		}
+
+        days_re_enable = 60
+
+        modifier = {
+			civilian_factory_use = 10
+        }
+
+		cost = 0
+		days_remove = 30
+
+		ai_will_do = {
+			factor = 400
+		}
+
+		complete_effect = {
+		}
+
+		remove_effect = {
+			add_equipment_to_stockpile = {
+				type = mechanized_equipment
+				producer = USA
+				amount = -2000
+			}
+			SOV = {
+				if = {
+					limit = {
+						USA = { has_tech = usa_mechanized_infantry_7 }
+					}
+					add_equipment_to_stockpile = { type = usa_mechanized_equipment_7 amount = 2000 producer = USA }
+				}
+				else_if = {
+					limit = {
+						USA = { has_tech = usa_mechanized_infantry_6 }
+					}
+					add_equipment_to_stockpile = { type = usa_mechanized_equipment_6 amount = 2000 producer = USA }
+				}
+				else_if = {
+					limit = {
+						USA = { has_tech = usa_mechanized_infantry_5 }
+					}
+					add_equipment_to_stockpile = { type = usa_mechanized_equipment_5 amount = 2000 producer = USA }
+				}
+				else_if = {
+					limit = {
+						USA = { has_tech = usa_mechanized_infantry_4 }
+					}
+					add_equipment_to_stockpile = { type = usa_mechanized_equipment_4 = 2000 producer = USA }
+				}
+				else_if = {
+					limit = {
+						USA = { has_tech = usa_mechanized_infantry_3 }
+					}
+					add_equipment_to_stockpile = { type = usa_mechanized_equipment_3 amount = 2000 producer = USA }
+				}
+				else_if = {
+					limit = {
+						USA = { has_tech = usa_mechanized_infantry_2 }
+					}
+					add_equipment_to_stockpile = { type = usa_mechanized_equipment_2 amount = 2000 producer = USA }
+				}
+				else = {
+					add_equipment_to_stockpile = { type = usa_mechanized_equipment_1 amount = 2000 producer = USA }
+				}
+			}
+		}
+	}
+	
+	USA_provide_mbts_ai = {
+
+		icon = generic_industry
+
+		allowed = {
+			original_tag = USA
+		}
+
+		visible = {
+			SOV = {
+				is_ai = yes
+			}
+			is_ai = yes
+			has_completed_focus = USA_lend_lease_act
+			SOV = { has_war_with = GER }
+			date > 1942.1.1
+		}
+
+		available = {
+			SOV = {
+				is_ai = yes
+				has_equipment = { modern_tank_chassis < 1 }
+			}
+			date > 1942.1.1
+			is_ai = yes
+			has_equipment = { modern_tank_chassis > 1499 }
+			original_tag = USA
+			has_completed_focus = USA_lend_lease_act
+			SOV = { has_war_with = GER }
+			NOT = { SOV = { has_war_with = USA } }
+			OR = {
+				has_government = democratic
+				SOV = { has_government = ROOT }
+				is_in_faction_with = SOV
+			}
+		}
+
+        days_re_enable = 60
+
+        modifier = {
+			civilian_factory_use = 10
+        }
+
+		cost = 0
+		days_remove = 30
+
+		ai_will_do = {
+			factor = 400
+		}
+
+		complete_effect = {
+			hidden_effect = {
+				set_country_flag = USA_soviet_aid_otw
+			}
+		}
+
+		remove_effect = {
+			add_equipment_to_stockpile = {
+				type = modern_tank_chassis
+				producer = USA
+				amount = -1000
+			}
+			SOV = {
+				if = {
+					limit = {
+						USA = { has_tech = usa_modern_tank_chassis_6 }
+					}
+					add_equipment_to_stockpile = { type = tank_usa_modern_chassis_6 amount = 1000 producer = USA }
+				}
+				else_if = {
+					limit = {
+						USA = { has_tech = usa_modern_tank_chassis_5 }
+					}
+					add_equipment_to_stockpile = { type = tank_usa_modern_chassis_5 amount = 1000 producer = USA }
+				}
+				else_if = {
+					limit = {
+						USA = { has_tech = usa_modern_tank_chassis_4 }
+					}
+					add_equipment_to_stockpile = { type = tank_usa_modern_chassis_4 = 1000 producer = USA }
+				}
+				else_if = {
+					limit = {
+						USA = { has_tech = usa_modern_tank_chassis_3 }
+					}
+					add_equipment_to_stockpile = { type = tank_usa_modern_chassis_3 amount = 1000 producer = USA }
+				}
+				else_if = {
+					limit = {
+						USA = { has_tech = usa_modern_tank_chassis_2 }
+					}
+					add_equipment_to_stockpile = { type = tank_usa_modern_chassis_2 amount = 1000 producer = USA }
+				}
+				else = {
+					add_equipment_to_stockpile = { type = tank_usa_modern_chassis_1 amount = 1000 producer = USA }
+				}
+			}
+		}
+	}
+	
+	USA_provide_fighterplanes_ai = {
+
+		icon = generic_industry
+
+		allowed = {
+			original_tag = USA
+		}
+
+		visible = {
+			SOV = {
+				is_ai = yes
+			}
+			is_ai = yes
+			has_completed_focus = USA_lend_lease_act
+			SOV = { has_war_with = GER }
+			date > 1942.1.1
+		}
+
+		available = {
+			SOV = {
+				is_ai = yes
+				has_deployed_air_force_size = { size < 4000 type = fighter }
+			}
+			date > 1942.1.1
+			is_ai = yes
+			original_tag = USA
+			has_completed_focus = USA_lend_lease_act
+			SOV = { has_war_with = GER }
+			NOT = { SOV = { has_war_with = USA } }
+			OR = {
+				has_government = democratic
+				SOV = { has_government = ROOT }
+				is_in_faction_with = SOV
+			}
+		}
+
+        days_re_enable = 60
+
+        modifier = {
+			civilian_factory_use = 10
+        }
+
+		cost = 0
+		days_remove = 30
+
+		ai_will_do = {
+			factor = 400
+		}
+
+		complete_effect = {
+		}
+
+		remove_effect = {
+			SOV = {
+				if = {
+					limit = {
+						USA = { has_tech = usa_jet_fighter_multirole_1 }
+					}
+					add_equipment_to_stockpile = { type = usa_jet_fighter_multirole_equipment_1 amount = 800 producer = USA }
+				}
+				else_if = {
+					limit = {
+						USA = { has_tech = usa_fighter_5 }
+					}
+					add_equipment_to_stockpile = { type = usa_fighter_equipment_6 amount = 800 producer = USA }
+				}
+				else_if = {
+					limit = {
+						USA = { has_tech = usa_fighter_3 }
+					}
+					add_equipment_to_stockpile = { type = usa_fighter_equipment_4 amount = 800 producer = USA }
+				}
+				else = {
+					add_equipment_to_stockpile = { type = usa_fighter_equipment_3 amount = 800 producer = USA }
+				}
+			}
+		}
+	}
+	
+	USA_provide_multirole_ai = {
+
+		icon = generic_industry
+
+		allowed = {
+			original_tag = USA
+		}
+
+		visible = {
+			SOV = {
+				is_ai = yes
+			}
+			is_ai = yes
+			has_completed_focus = USA_lend_lease_act
+			SOV = { has_war_with = GER }
+			date > 1942.1.1
+		}
+
+		available = {
+			SOV = {
+				is_ai = yes
+				has_deployed_air_force_size = { size < 2500 type = cas }
+			}
+			date > 1942.1.1
+			is_ai = yes
+			original_tag = USA
+			has_completed_focus = USA_lend_lease_act
+			SOV = { has_war_with = GER }
+			NOT = { SOV = { has_war_with = USA } }
+			OR = {
+				has_government = democratic
+				SOV = { has_government = ROOT }
+				is_in_faction_with = SOV
+			}
+		}
+
+        days_re_enable = 60
+
+        modifier = {
+			civilian_factory_use = 10
+        }
+
+		cost = 0
+		days_remove = 30
+
+		ai_will_do = {
+			factor = 400
+		}
+
+		complete_effect = {
+		}
+
+		remove_effect = {
+			SOV = {
+				if = {
+					limit = {
+						USA = { has_tech = usa_fighter_multirole_3 }
+					}
+					add_equipment_to_stockpile = { type = usa_fighter_multirole_equipment_3 amount = 800 producer = USA }
+				}
+				else_if = {
+					limit = {
+						USA = { has_tech = usa_fighter_multirole_2 }
+					}
+					add_equipment_to_stockpile = { type = usa_fighter_multirole_equipment_2 amount = 800 producer = USA }
+				}
+				else = {
+					add_equipment_to_stockpile = { type = usa_fighter_multirole_equipment_1 amount = 800 producer = USA }
+				}
+			}
+		}
+	}
 }
 
 

--- a/common/decisions/USA.txt
+++ b/common/decisions/USA.txt
@@ -2960,6 +2960,7 @@ USA_aid_britain = {
 					}
 				}
 				add_ideas = partial_economic_mobilisation
+				USA_great_depression_level_down = yes
 			}
 			if = {
 				limit = {
@@ -2971,6 +2972,7 @@ USA_aid_britain = {
 					}
 				}
 				add_ideas = tot_economic_mobilisation
+				USA_great_depression_level_down = yes
 			}			
 		}
 	}

--- a/common/decisions/USA.txt
+++ b/common/decisions/USA.txt
@@ -2915,6 +2915,15 @@ USA_aid_britain = {
 		complete_effect = {
 			news_event = { id = afo_news.9 hours = 6 }
 			play_arsenal_of_democracy_effect = yes
+			if = {
+				limit = {
+					USA = {
+						is_ai = yes
+						has_war = yes
+					}
+				}
+				add_ideas = partial_economic_mobilisation
+			}		
 		}
 	}
 }

--- a/common/decisions/USA.txt
+++ b/common/decisions/USA.txt
@@ -4381,19 +4381,19 @@ USA_aid_soviet_union = {
 			add_equipment_to_stockpile = {
 				type = support_equipment_1
 				producer = USA
-				amount = -10000
+				amount = -15000
 			}
 			SOV = {
 				add_equipment_to_stockpile = {
 					type = support_equipment_1
 					producer = USA
-					amount = 10000
+					amount = 15000
 				}
 			}
 		}
 	}
 	
-	USA_provide_guns_ai = {
+	USA_provide_heavyguns_ai = {
 
 		icon = generic_industry
 
@@ -4450,53 +4450,144 @@ USA_aid_soviet_union = {
 			add_equipment_to_stockpile = {
 				type = heavy_infantry_equipment
 				producer = USA
-				amount = -15000
+				amount = -17500
 			}
 			SOV = {
 				if = {
 					limit = {
 						USA = { has_tech = usa_heavy_infantry_weapons_8 }
 					}
-					add_equipment_to_stockpile = { type = usa_hv_inf_8 amount = 15000 producer = USA }
+					add_equipment_to_stockpile = { type = usa_hv_inf_8 amount = 17500 producer = USA }
 				}
 				else_if = {
 					limit = {
 						USA = { has_tech = usa_heavy_infantry_weapons_7 }
 					}
-					add_equipment_to_stockpile = { type = usa_hv_inf_7 amount = 15000 producer = USA }
+					add_equipment_to_stockpile = { type = usa_hv_inf_7 amount = 17500 producer = USA }
 				}
 				else_if = {
 					limit = {
 						USA = { has_tech = usa_heavy_infantry_weapons_6 }
 					}
-					add_equipment_to_stockpile = { type = usa_hv_inf_6 amount = 15000 producer = USA }
+					add_equipment_to_stockpile = { type = usa_hv_inf_6 amount = 17500 producer = USA }
 				}
 				else_if = {
 					limit = {
 						USA = { has_tech = usa_heavy_infantry_weapons_5 }
 					}
-					add_equipment_to_stockpile = { type = usa_hv_inf_5 amount = 15000 producer = USA }
+					add_equipment_to_stockpile = { type = usa_hv_inf_5 amount = 17500 producer = USA }
 				}
 				else_if = {
 					limit = {
 						USA = { has_tech = usa_heavy_infantry_weapons_4 }
 					}
-					add_equipment_to_stockpile = { type = usa_hv_inf_4 amount = 15000 producer = USA }
+					add_equipment_to_stockpile = { type = usa_hv_inf_4 amount = 17500 producer = USA }
 				}
 				else_if = {
 					limit = {
 						USA = { has_tech = usa_heavy_infantry_weapons_3 }
 					}
-					add_equipment_to_stockpile = { type = usa_hv_inf_3 amount = 15000 producer = USA }
+					add_equipment_to_stockpile = { type = usa_hv_inf_3 amount = 17500 producer = USA }
 				}
 				else_if = {
 					limit = {
 						USA = { has_tech = usa_heavy_infantry_weapons_2 }
 					}
-					add_equipment_to_stockpile = { type = usa_hv_inf_2 amount = 15000 producer = USA }
+					add_equipment_to_stockpile = { type = usa_hv_inf_2 amount = 17500 producer = USA }
 				}
 				else = {
-					add_equipment_to_stockpile = { type = usa_hv_inf_1 amount = 15000 producer = USA }
+					add_equipment_to_stockpile = { type = usa_hv_inf_1 amount = 17500 producer = USA }
+				}
+			}
+		}
+	}
+	
+	USA_provide_smolguns_ai = {
+
+		icon = generic_industry
+
+		allowed = {
+			original_tag = USA
+		}
+
+		visible = {
+			SOV = {
+				is_ai = yes
+			}
+			is_ai = yes
+			has_completed_focus = USA_lend_lease_act
+			SOV = { has_war_with = GER }
+			date > 1942.1.1
+		}
+
+		available = {
+			SOV = {
+				is_ai = yes
+				has_equipment = { infantry_equipment < 1 }
+			}
+			date > 1942.1.1
+			is_ai = yes
+			has_equipment = { infantry_equipment > 39999 }
+			original_tag = USA
+			has_completed_focus = USA_lend_lease_act
+			SOV = { has_war_with = GER }
+			NOT = { SOV = { has_war_with = USA } }
+			OR = {
+				has_government = democratic
+				SOV = { has_government = ROOT }
+				is_in_faction_with = SOV
+			}
+		}
+
+        days_re_enable = 60
+
+        modifier = {
+			civilian_factory_use = 10
+        }
+
+		cost = 0
+		days_remove = 30
+
+		ai_will_do = {
+			factor = 400
+		}
+
+		complete_effect = {
+		}
+
+		remove_effect = {
+			add_equipment_to_stockpile = {
+				type = infantry_equipment
+				producer = USA
+				amount = -40000
+			}
+			SOV = {
+				if = {
+					limit = {
+						USA = { has_tech = usa_infantry_weapons_8 }
+					}
+					add_equipment_to_stockpile = { type = usa_inf_8 amount = 40000 producer = USA }
+				}
+				else_if = {
+					limit = {
+						USA = { has_tech = usa_infantry_weapons_7 }
+					}
+					add_equipment_to_stockpile = { type = usa_inf_7 amount = 40000 producer = USA }
+				}
+				else_if = {
+					limit = {
+						USA = { has_tech = usa_infantry_weapons_6 }
+					}
+					add_equipment_to_stockpile = { type = usa_inf_6 amount = 40000 producer = USA }
+				}
+				else_if = {
+					limit = {
+						USA = { has_tech = usa_infantry_weapons_4 }
+					}
+					add_equipment_to_stockpile = { type = usa_inf_4 amount = 40000 producer = USA }
+				}
+				else = {
+					add_equipment_to_stockpile = { type = usa_inf_3 amount = 40000 producer = USA }
 				}
 			}
 		}
@@ -4811,7 +4902,7 @@ USA_aid_soviet_union = {
 		available = {
 			SOV = {
 				is_ai = yes
-				has_deployed_air_force_size = { size < 4000 type = fighter }
+				has_deployed_air_force_size = { size < 5500 type = fighter }
 			}
 			date > 1942.1.1
 			is_ai = yes
@@ -4826,7 +4917,7 @@ USA_aid_soviet_union = {
 			}
 		}
 
-        days_re_enable = 60
+        days_re_enable = 45
 
         modifier = {
 			civilian_factory_use = 10
@@ -4846,30 +4937,61 @@ USA_aid_soviet_union = {
 			SOV = {
 				if = {
 					limit = {
-						USA = { has_tech = usa_jet_fighter_multirole_1 }
+						date < 1945.1.1
 					}
-					add_equipment_to_stockpile = { type = usa_jet_fighter_multirole_equipment_1 amount = 800 producer = USA }
+					if = {
+						limit = {
+							USA = { has_tech = usa_jet_fighter_multirole_1 }
+						}
+						add_equipment_to_stockpile = { type = usa_jet_fighter_multirole_equipment_1 amount = 800 producer = USA }
+					}
+					else_if = {
+						limit = {
+							USA = { has_tech = usa_fighter_5 }
+						}
+						add_equipment_to_stockpile = { type = usa_fighter_equipment_6 amount = 800 producer = USA }
+					}
+					else_if = {
+						limit = {
+							USA = { has_tech = usa_fighter_3 }
+						}
+						add_equipment_to_stockpile = { type = usa_fighter_equipment_4 amount = 800 producer = USA }
+					}
+					else = {
+						add_equipment_to_stockpile = { type = usa_fighter_equipment_3 amount = 800 producer = USA }
+					}
 				}
-				else_if = {
+				if = {
 					limit = {
-						USA = { has_tech = usa_fighter_5 }
+						date > 1945.1.1
 					}
-					add_equipment_to_stockpile = { type = usa_fighter_equipment_6 amount = 800 producer = USA }
-				}
-				else_if = {
-					limit = {
-						USA = { has_tech = usa_fighter_3 }
+					if = {
+						limit = {
+							USA = { has_tech = usa_jet_fighter_multirole_1 }
+						}
+						add_equipment_to_stockpile = { type = usa_jet_fighter_multirole_equipment_1 amount = 1200 producer = USA }
 					}
-					add_equipment_to_stockpile = { type = usa_fighter_equipment_4 amount = 800 producer = USA }
-				}
-				else = {
-					add_equipment_to_stockpile = { type = usa_fighter_equipment_3 amount = 800 producer = USA }
+					else_if = {
+						limit = {
+							USA = { has_tech = usa_fighter_5 }
+						}
+						add_equipment_to_stockpile = { type = usa_fighter_equipment_6 amount = 1200 producer = USA }
+					}
+					else_if = {
+						limit = {
+							USA = { has_tech = usa_fighter_3 }
+						}
+						add_equipment_to_stockpile = { type = usa_fighter_equipment_4 amount = 1200 producer = USA }
+					}
+					else = {
+						add_equipment_to_stockpile = { type = usa_fighter_equipment_3 amount = 1200 producer = USA }
+					}
 				}
 			}
 		}
 	}
 	
-	USA_provide_multirole_ai = {
+	USA_provide_cas_ai = {
 
 		icon = generic_industry
 
@@ -4878,24 +5000,26 @@ USA_aid_soviet_union = {
 		}
 
 		visible = {
+			has_tech = usa_fighter_multirole_3
 			SOV = {
 				is_ai = yes
 			}
 			is_ai = yes
 			has_completed_focus = USA_lend_lease_act
 			SOV = { has_war_with = GER }
-			date > 1942.1.1
+			date > 1944.1.1
 		}
 
 		available = {
 			SOV = {
 				is_ai = yes
-				has_deployed_air_force_size = { size < 2500 type = cas }
+				has_deployed_air_force_size = { size < 3000 type = cas }
 			}
-			date > 1942.1.1
+			date > 1944.1.1
 			is_ai = yes
 			original_tag = USA
 			has_completed_focus = USA_lend_lease_act
+			has_tech = usa_fighter_multirole_3
 			SOV = { has_war_with = GER }
 			NOT = { SOV = { has_war_with = USA } }
 			OR = {
@@ -4923,21 +5047,7 @@ USA_aid_soviet_union = {
 
 		remove_effect = {
 			SOV = {
-				if = {
-					limit = {
-						USA = { has_tech = usa_fighter_multirole_3 }
-					}
-					add_equipment_to_stockpile = { type = usa_fighter_multirole_equipment_3 amount = 800 producer = USA }
-				}
-				else_if = {
-					limit = {
-						USA = { has_tech = usa_fighter_multirole_2 }
-					}
-					add_equipment_to_stockpile = { type = usa_fighter_multirole_equipment_2 amount = 800 producer = USA }
-				}
-				else = {
-					add_equipment_to_stockpile = { type = usa_fighter_multirole_equipment_1 amount = 800 producer = USA }
-				}
+				add_equipment_to_stockpile = { type = usa_fighter_multirole_equipment_3 amount = 400 producer = USA }
 			}
 		}
 	}

--- a/common/decisions/USA.txt
+++ b/common/decisions/USA.txt
@@ -2895,7 +2895,12 @@ USA_aid_britain = {
 		}
 
 		visible = {
-			has_war = no
+			OR = {
+				has_war = no
+				ENG = {
+					has_country_leader = { ruling_only = yes name = "George VI" }
+				}
+			}
 		}
 
 		modifier = {

--- a/common/decisions/USA.txt
+++ b/common/decisions/USA.txt
@@ -2914,16 +2914,64 @@ USA_aid_britain = {
 
 		complete_effect = {
 			news_event = { id = afo_news.9 hours = 6 }
-			play_arsenal_of_democracy_effect = yes
+			play_arsenal_of_democracy_effect = yes		
+		}
+	}
+	
+	USA_alt_hist_earlymob = { #the uk is dead, override EAI and mobilize.
+
+		icon = generic_industry
+
+		allowed = {
+			original_tag = USA
+		}
+
+		available = {
+			date < 1941.12.1
+			has_country_leader = { ruling_only = yes name = "Franklin Delano Roosevelt" }
+			is_ai = yes
+			has_war = yes
+			ENG = {
+				has_country_leader = { ruling_only = yes name = "George VI" }
+			}
+		}
+
+		cost = 0
+		fire_only_once = yes
+		ai_will_do = {
+			factor = 4000
+		}
+
+		visible = {
+			date < 1942.12.1
+			is_ai = yes
+			has_war = yes
+			ENG = {
+				has_country_leader = { ruling_only = yes name = "George VI" }
+			}
+		}
+
+		complete_effect = {
 			if = {
 				limit = {
-					USA = {
-						is_ai = yes
-						has_war = yes
+					OR = {
+						has_idea = undisturbed_isolation
+						has_idea = isolation
 					}
 				}
 				add_ideas = partial_economic_mobilisation
-			}		
+			}
+			if = {
+				limit = {
+					OR = {
+						has_idea = civilian_economy
+						has_idea = low_economic_mobilisation
+						has_idea = partial_economic_mobilisation
+						has_idea = war_economy
+					}
+				}
+				add_ideas = tot_economic_mobilisation
+			}			
 		}
 	}
 }

--- a/common/decisions/USA.txt
+++ b/common/decisions/USA.txt
@@ -734,6 +734,175 @@ MTG_naval_treaties = {
 
 war_measures = {
 
+	USA_build_airbasesinUK_ai = {
+		icon = generic_construction
+
+		available = {
+			num_of_civilian_factories_available_for_projects > 119
+			tag = USA
+			is_ai = yes
+			ENG = {
+				is_ai = yes
+			}
+			date > 1943.12.1
+			has_war_with = GER
+			is_in_faction_with = ENG
+			126 = {
+				CONTROLLER = { 
+					tag = ENG 
+				}
+			}
+		}
+		visible = {
+			tag = USA
+			is_ai = yes
+			date > 1943.12.1
+			has_war_with = GER
+			is_in_faction_with = ENG
+		}
+
+		cancel_if_not_visible = yes
+
+		fire_only_once = yes
+
+		cost = 0
+
+		ai_will_do = {
+			factor = 320
+		}
+
+		days_remove = 90
+
+		modifier = {
+			civilian_factory_use = 120
+		}
+
+		remove_effect = {
+			custom_effect_tooltip = USA_fortify_uk_tt
+			hidden_effect = {
+				961 = {
+					add_building_construction = {
+						type = air_base
+						level = 10
+						instant_build = yes
+					}
+				}
+				858 = {
+					add_building_construction = {
+						type = air_base
+						level = 3
+						instant_build = yes
+					}
+				}
+				127 = {
+					add_building_construction = {
+						type = air_base
+						level = 3
+						instant_build = yes
+					}
+				}
+				859 = {
+					add_building_construction = {
+						type = air_base
+						level = 8
+						instant_build = yes
+					}
+				}
+				123 = {
+					add_building_construction = {
+						type = air_base
+						level = 8
+						instant_build = yes
+					}
+				}
+				338 = {
+					add_building_construction = {
+						type = air_base
+						level = 4
+						instant_build = yes
+					}
+				}
+				122 = {
+					add_building_construction = {
+						type = air_base
+						level = 10
+						instant_build = yes
+					}
+				}
+				128 = {
+					add_building_construction = {
+						type = air_base
+						level = 5
+						instant_build = yes
+					}
+				}
+				129 = {
+					add_building_construction = {
+						type = air_base
+						level = 5
+						instant_build = yes
+					}
+				}
+				125 = {
+					add_building_construction = {
+						type = air_base
+						level = 6
+						instant_build = yes
+					}
+				}
+				860 = {
+					add_building_construction = {
+						type = air_base
+						level = 7
+						instant_build = yes
+					}
+				}
+				132 = {
+					add_building_construction = {
+						type = air_base
+						level = 7
+						instant_build = yes
+					}
+				}
+				131 = {
+					add_building_construction = {
+						type = air_base
+						level = 9
+						instant_build = yes
+					}
+				}
+				121 = {
+					add_building_construction = {
+						type = air_base
+						level = 7
+						instant_build = yes
+					}
+				}
+				133 = {
+					add_building_construction = {
+						type = air_base
+						level = 7
+						instant_build = yes
+					}
+				}
+				136 = {
+					add_building_construction = {
+						type = air_base
+						level = 6
+						instant_build = yes
+					}
+				}
+				119 = {
+					add_building_construction = {
+						type = air_base
+						level = 9
+						instant_build = yes
+					}
+				}
+			}
+		}
+	}
+
 	long_island_ship_conversion = {
 
 		allowed = {

--- a/common/decisions/USA_factions.txt
+++ b/common/decisions/USA_factions.txt
@@ -851,6 +851,14 @@ USA_internal_factions = {
 		}
 
 		activation = {
+			if = {
+				limit = {
+					NOT = {
+						has_war_with = JAP
+					}
+				}
+				date > 1941.11.1
+			}
 			OR = {
 				date < 1943.12.1
 				AND = {
@@ -1062,6 +1070,14 @@ USA_internal_factions = {
 		}
 
 		activation = {
+			if = {
+				limit = {
+					NOT = {
+						has_war_with = JAP
+					}
+				}
+				date > 1941.11.1
+			}
 			OR = {
 				date < 1943.12.1
 				AND = {

--- a/common/decisions/USA_factions.txt
+++ b/common/decisions/USA_factions.txt
@@ -853,11 +853,12 @@ USA_internal_factions = {
 		activation = {
 			if = {
 				limit = {
+					is_ai = yes
 					NOT = {
 						has_war_with = JAP
 					}
 				}
-				date > 1941.11.1
+				date > 1941.12.1
 			}
 			OR = {
 				date < 1943.12.1
@@ -1072,11 +1073,12 @@ USA_internal_factions = {
 		activation = {
 			if = {
 				limit = {
+					is_ai = yes
 					NOT = {
 						has_war_with = JAP
 					}
 				}
-				date > 1941.11.1
+				date > 1941.12.1
 			}
 			OR = {
 				date < 1943.12.1

--- a/common/decisions/_generic_decisions.txt
+++ b/common/decisions/_generic_decisions.txt
@@ -533,6 +533,46 @@ political_actions = {
 		complete_effect = {
         }
 	}
+	
+	sovietai_cant_deal_with_airzones = {
+
+		icon = generic_operation
+
+        allowed = {
+            always = yes
+        }
+
+        available = {
+        	is_ai = yes
+			tag = SOV
+			date > 1936.1.1
+        }
+
+        visible = {
+        	is_ai = yes
+			tag = SOV
+			date > 1936.1.1
+        }
+
+        cost = 0
+        days_remove = 100000
+        fire_only_once = yes
+
+        remove_trigger = {
+        	is_ai = no
+        }
+
+        modifier = {
+			air_mission_efficiency = 2.0
+        }
+
+        ai_will_do = {
+			factor = 150
+		}
+
+		complete_effect = {
+        }
+	}
 
 	AI_usa_infra = {
 

--- a/common/decisions/_generic_decisions.txt
+++ b/common/decisions/_generic_decisions.txt
@@ -4906,7 +4906,6 @@ war_measures = {
 
 		complete_effect = {
 			replace_civ_with_arms_factories = yes
-			add_war_support = -0.05
 		}
 		ai_will_do = {
 			factor = 0
@@ -4933,8 +4932,7 @@ war_measures = {
 
 		complete_effect = {
 			replace_civ_with_arms_factories = yes
-			add_war_support = -0.05
-			add_stability = -0.03
+			add_war_support = -0.02
 		}
 		ai_will_do = {
 			factor = 0

--- a/common/decisions/_generic_decisions.txt
+++ b/common/decisions/_generic_decisions.txt
@@ -476,7 +476,7 @@ political_actions = {
         }
 
         modifier = {
-			production_speed_rail_way_factor = 10.0
+			production_speed_rail_way_factor = 100.0
 			production_speed_naval_base_factor = 100.0
         }
 

--- a/common/decisions/economy_fatigue_decisions.txt
+++ b/common/decisions/economy_fatigue_decisions.txt
@@ -53,7 +53,7 @@ economy_decisions = {
 				}
 				add_building_construction = {
 					type = industrial_complex
-					level = 5
+					level = 3
 					instant_build = yes
 				}
 			}
@@ -68,7 +68,7 @@ economy_decisions = {
 				}
 				add_building_construction = {
 					type = industrial_complex
-					level = 5
+					level = 3
 					instant_build = yes
 				}
 			}
@@ -207,7 +207,7 @@ economy_decisions = {
 				}
 				add_building_construction = {
 					type = industrial_complex
-					level = 5
+					level = 3
 					instant_build = yes
 				}
 			}

--- a/common/decisions/reserves.txt
+++ b/common/decisions/reserves.txt
@@ -3677,7 +3677,7 @@ reserve_divisions = {
 				add = 200
 				tag = SOV
 				GER = { is_ai = no }
-				num_divisions < 250
+				num_divisions < 275
 				OR = {
 					NOT = {	SOV = { has_full_control_of_state = 209 }}
 					NOT = {	SOV = { has_full_control_of_state = 210 }}
@@ -3706,7 +3706,7 @@ reserve_divisions = {
 				add = 200
 				tag = SOV
 				GER = { is_ai = yes }
-				num_divisions < 250
+				num_divisions < 275
 				OR = {
 					NOT = {	SOV = { has_full_control_of_state = 208 }}
 					NOT = {	SOV = { has_full_control_of_state = 263 }}

--- a/common/ideas/army_spirits.txt
+++ b/common/ideas/army_spirits.txt
@@ -531,6 +531,7 @@ ideas = {
 				modifier = {
 					factor = 40
 					tag = SOV
+					NOT = { has_country_flag = army_is_reformed }
 				}
 			}
 		}
@@ -886,6 +887,7 @@ ideas = {
 				modifier = {
 					factor = 40
 					tag = SOV
+					NOT = { has_country_flag = army_is_reformed }
 				}
 
 				modifier = {

--- a/common/ideas/soviet.txt
+++ b/common/ideas/soviet.txt
@@ -10625,7 +10625,7 @@ ideas = {
 			}
 
 			ai_will_do = {
-				factor = 3
+				factor = 40
 			}
 		}
 

--- a/common/national_focus/usa.txt
+++ b/common/national_focus/usa.txt
@@ -2993,7 +2993,7 @@ focus_tree = {
 		}
 
 		cancel_if_invalid = no
-		continue_if_invalid = no
+		#continue_if_invalid = no
 		available_if_capitulated = no
 
 		completion_reward = {

--- a/common/national_focus/usa.txt
+++ b/common/national_focus/usa.txt
@@ -3154,7 +3154,7 @@ focus_tree = {
 		}
 
 		cancel_if_invalid = no
-		continue_if_invalid = no
+		#continue_if_invalid = no
 		available_if_capitulated = no
 
 		completion_reward = {

--- a/common/technologies/air_doctrine.txt
+++ b/common/technologies/air_doctrine.txt
@@ -147,18 +147,10 @@ technologies = {
 				factor = 0.4
 				is_major = no
 			}
-			
-			modifier = {
-				factor = 0
-				tag = GER
-			}
 
 			modifier = {
 				factor = 0
-				tag = SOV
-				NOT = { 
-					has_country_flag = SOV_air_reform_2
-				}
+				tag = GER
 			}
 
 			modifier = {
@@ -371,14 +363,6 @@ technologies = {
 			modifier = {
 				factor = 0.4
 				is_major = no
-			}
-			
-			modifier = {
-				factor = 0
-				tag = SOV
-				NOT = { 
-					has_country_flag = SOV_air_reform_2
-				}
 			}
 
 			modifier = {
@@ -728,14 +712,6 @@ technologies = {
 				factor = 0
 				tag = ITA
 			}
-			
-			modifier = {
-				factor = 0
-				tag = SOV
-				NOT = { 
-					has_country_flag = SOV_air_reform_2
-				}
-			}
 
 			modifier = {
 				factor = 0
@@ -928,14 +904,6 @@ technologies = {
 				factor = 0.4
 				is_major = no
 			}
-			
-			modifier = {
-				factor = 0
-				tag = SOV
-				NOT = { 
-					has_country_flag = SOV_air_reform_2
-				}
-			}
 
 			modifier = {
 				factor = 0
@@ -984,14 +952,6 @@ technologies = {
 			modifier = {
 				factor = 0.4
 				is_major = no
-			}
-			
-			modifier = {
-				factor = 0
-				tag = SOV
-				NOT = { 
-					has_country_flag = SOV_air_reform_2
-				}
 			}
 
 			modifier = {
@@ -1124,14 +1084,6 @@ technologies = {
 				factor = 0.4
 				is_major = no
 			}
-			
-			modifier = {
-				factor = 0
-				tag = SOV
-				NOT = { 
-					has_country_flag = SOV_air_reform_2
-				}
-			}
 
 			modifier = {
 				factor = 0
@@ -1184,14 +1136,6 @@ technologies = {
 			modifier = {
 				factor = 0.4
 				is_major = no
-			}
-			
-			modifier = {
-				factor = 0
-				tag = SOV
-				NOT = { 
-					has_country_flag = SOV_air_reform_2
-				}
 			}
 
 			modifier = {
@@ -1342,14 +1286,6 @@ technologies = {
 			modifier = {
 				factor = 0.4
 				is_major = no
-			}
-			
-			modifier = {
-				factor = 0
-				tag = SOV
-				NOT = { 
-					has_country_flag = SOV_air_reform_2
-				}
 			}
 
 			modifier = {
@@ -1588,14 +1524,6 @@ technologies = {
 				factor = 0.4
 				tag = GER
 			}
-			
-			modifier = {
-				factor = 0
-				tag = SOV
-				NOT = { 
-					has_country_flag = SOV_air_reform_2
-				}
-			}
 
 			modifier = {
 				factor = 0
@@ -1801,14 +1729,6 @@ technologies = {
 				factor = 0
 				tag = ENG
 			}
-			
-			modifier = {
-				factor = 0
-				tag = SOV
-				NOT = { 
-					has_country_flag = SOV_air_reform_2
-				}
-			}
 
 			modifier = {
 				factor = 0
@@ -1862,14 +1782,6 @@ technologies = {
 			modifier = {
 				factor = 0
 				tag = USA
-			}
-			
-			modifier = {
-				factor = 0
-				tag = SOV
-				NOT = { 
-					has_country_flag = SOV_air_reform_2
-				}
 			}
 
 			modifier = {
@@ -2010,14 +1922,6 @@ technologies = {
 			modifier = {
 				factor = 0.4
 				tag = GER
-			}
-			
-			modifier = {
-				factor = 0
-				tag = SOV
-				NOT = { 
-					has_country_flag = SOV_air_reform_2
-				}
 			}
 
 			modifier = {

--- a/common/technologies/air_doctrine.txt
+++ b/common/technologies/air_doctrine.txt
@@ -147,10 +147,18 @@ technologies = {
 				factor = 0.4
 				is_major = no
 			}
-
+			
 			modifier = {
 				factor = 0
 				tag = GER
+			}
+
+			modifier = {
+				factor = 0
+				tag = SOV
+				NOT = { 
+					has_country_flag = SOV_air_reform_2
+				}
 			}
 
 			modifier = {
@@ -363,6 +371,14 @@ technologies = {
 			modifier = {
 				factor = 0.4
 				is_major = no
+			}
+			
+			modifier = {
+				factor = 0
+				tag = SOV
+				NOT = { 
+					has_country_flag = SOV_air_reform_2
+				}
 			}
 
 			modifier = {
@@ -712,6 +728,14 @@ technologies = {
 				factor = 0
 				tag = ITA
 			}
+			
+			modifier = {
+				factor = 0
+				tag = SOV
+				NOT = { 
+					has_country_flag = SOV_air_reform_2
+				}
+			}
 
 			modifier = {
 				factor = 0
@@ -904,6 +928,14 @@ technologies = {
 				factor = 0.4
 				is_major = no
 			}
+			
+			modifier = {
+				factor = 0
+				tag = SOV
+				NOT = { 
+					has_country_flag = SOV_air_reform_2
+				}
+			}
 
 			modifier = {
 				factor = 0
@@ -952,6 +984,14 @@ technologies = {
 			modifier = {
 				factor = 0.4
 				is_major = no
+			}
+			
+			modifier = {
+				factor = 0
+				tag = SOV
+				NOT = { 
+					has_country_flag = SOV_air_reform_2
+				}
 			}
 
 			modifier = {
@@ -1084,6 +1124,14 @@ technologies = {
 				factor = 0.4
 				is_major = no
 			}
+			
+			modifier = {
+				factor = 0
+				tag = SOV
+				NOT = { 
+					has_country_flag = SOV_air_reform_2
+				}
+			}
 
 			modifier = {
 				factor = 0
@@ -1136,6 +1184,14 @@ technologies = {
 			modifier = {
 				factor = 0.4
 				is_major = no
+			}
+			
+			modifier = {
+				factor = 0
+				tag = SOV
+				NOT = { 
+					has_country_flag = SOV_air_reform_2
+				}
 			}
 
 			modifier = {
@@ -1286,6 +1342,14 @@ technologies = {
 			modifier = {
 				factor = 0.4
 				is_major = no
+			}
+			
+			modifier = {
+				factor = 0
+				tag = SOV
+				NOT = { 
+					has_country_flag = SOV_air_reform_2
+				}
 			}
 
 			modifier = {
@@ -1524,6 +1588,14 @@ technologies = {
 				factor = 0.4
 				tag = GER
 			}
+			
+			modifier = {
+				factor = 0
+				tag = SOV
+				NOT = { 
+					has_country_flag = SOV_air_reform_2
+				}
+			}
 
 			modifier = {
 				factor = 0
@@ -1729,6 +1801,14 @@ technologies = {
 				factor = 0
 				tag = ENG
 			}
+			
+			modifier = {
+				factor = 0
+				tag = SOV
+				NOT = { 
+					has_country_flag = SOV_air_reform_2
+				}
+			}
 
 			modifier = {
 				factor = 0
@@ -1782,6 +1862,14 @@ technologies = {
 			modifier = {
 				factor = 0
 				tag = USA
+			}
+			
+			modifier = {
+				factor = 0
+				tag = SOV
+				NOT = { 
+					has_country_flag = SOV_air_reform_2
+				}
 			}
 
 			modifier = {
@@ -1922,6 +2010,14 @@ technologies = {
 			modifier = {
 				factor = 0.4
 				tag = GER
+			}
+			
+			modifier = {
+				factor = 0
+				tag = SOV
+				NOT = { 
+					has_country_flag = SOV_air_reform_2
+				}
 			}
 
 			modifier = {

--- a/common/technologies/land_doctrine.txt
+++ b/common/technologies/land_doctrine.txt
@@ -2495,7 +2495,10 @@ technologies = {
 				factor = 0
 				has_army_experience < 105
 				NOT = {
-					has_completed_focus = GER_refinement_of_bewegungskrieg
+					OR = {
+						has_completed_focus = GER_refinement_of_bewegungskrieg
+						has_completed_focus = SOV_perfecting_the_armour_corps
+					}
 				}
 			}
 		}
@@ -2671,6 +2674,7 @@ technologies = {
 			modifier = {
 				factor = 0
 				has_army_experience < 105
+				NOT = { has_completed_focus = SOV_perfecting_the_armour_corps }
 			}
 			modifier = {
 				factor = 0
@@ -3794,7 +3798,10 @@ technologies = {
 				factor = 0
 				has_army_experience < 105
 				NOT = {
-					has_completed_focus = GER_total_sturmtruppen_prominence
+					OR = {
+						has_completed_focus = GER_total_sturmtruppen_prominence
+						has_completed_focus = SOV_perfecting_the_infantry_corps
+					}
 				}
 			}
 		}
@@ -3852,10 +3859,7 @@ technologies = {
 			}
 			modifier = {
 				factor = 0
-				tag = SOV
-			}
-			modifier = {
-				factor = 0
+				NOT = { has_completed_focus = SOV_perfecting_the_infantry_corps }
 				has_army_experience < 105
 			}
 		}
@@ -3908,6 +3912,10 @@ technologies = {
 			}
 			modifier = {
 				factor = 0
+				tag = SOV
+			}
+			modifier = {
+				factor = 0
 				has_army_experience < 105
 			}
 		}
@@ -3950,6 +3958,10 @@ technologies = {
 				factor = 0
 				has_army_experience < 105
 			}
+			modifier = {
+				factor = 0
+				tag = SOV
+			}
 		}
 	}
 	mortar_pits = {
@@ -3990,6 +4002,7 @@ technologies = {
 			}
 			modifier = {
 				factor = 0
+				NOT = { has_completed_focus = SOV_perfecting_the_infantry_corps }
 				has_army_experience < 105
 			}
 		}
@@ -4028,6 +4041,10 @@ technologies = {
 				factor = 0
 				has_army_experience < 105
 			}
+			modifier = {
+				factor = 0
+				tag = SOV
+			}
 		}
 	}
 	blob_formations = {
@@ -4064,6 +4081,7 @@ technologies = {
 			}
 			modifier = {
 				factor = 0
+				NOT = { has_completed_focus = SOV_perfecting_the_infantry_corps }
 				has_army_experience < 105
 			}
 		}
@@ -4124,6 +4142,7 @@ technologies = {
 			}
 			modifier = {
 				factor = 0
+				NOT = { has_completed_focus = SOV_perfecting_the_infantry_corps }
 				has_army_experience < 105
 			}
 		}

--- a/events/wa_sov_events.txt
+++ b/events/wa_sov_events.txt
@@ -788,6 +788,7 @@ country_event = {
 				armoured_recon = { x = 1 y = 0 }
 				motorized_rocket = { x = 1 y = 1 }
 				heavy_assault = { x = 1 y = 2 }
+				anti_air = { x = 1 y = 3 }
 			}
 		}
 		219 = {

--- a/events/wa_usa_events.txt
+++ b/events/wa_usa_events.txt
@@ -4056,6 +4056,28 @@ country_event = {
 }
 
 country_event = {
+	id = usa_armor.926
+	hidden = yes
+
+	mean_time_to_happen = { days = 1 }
+
+	fire_only_once = yes
+
+	trigger = {
+		date > 1942.7.1
+		tag = USA
+		is_ai = yes
+	}
+
+	immediate = {
+		add_political_power = 1200
+	}
+
+	option = {}
+
+}
+
+country_event = {
 	id = usa_armor.925
 	hidden = yes
 

--- a/localisation/english/wtt_decisions_l_english.yml
+++ b/localisation/english/wtt_decisions_l_english.yml
@@ -339,7 +339,7 @@
  emergency_factory_conversion_defensive:0 "Emergency Factory Conversion"
  emergency_factory_conversion_defensive_desc:0 "More equipment is desperately needed on the front. We urgently need to convert more factories to produce arms and vehicles to defend our country."
  emergency_factory_conversion_offensive:0 "Emergency Factory Conversion"
- emergency_factory_conversion_offensive_desc:0 "The our troops urgently need more equipment. More factories are needed to produce the equipment required to win the war."
+ emergency_factory_conversion_offensive_desc:0 "Our troops urgently need more equipment. More factories are needed to produce the equipment required to win the war."
  demolish_enemy_fortifications:0 "Demolish Enemy Fortifications"
  dismantle_maginot:0 "Dismantle Maginot"
  propaganda_efforts:0 "Propaganda Efforts"

--- a/localisation/replace/afo_ground_l_russian.yml
+++ b/localisation/replace/afo_ground_l_russian.yml
@@ -2258,7 +2258,7 @@
 
     sov_heavy_equipment_11:0 "IS-7"
     sov_heavy_equipment_11_short:0 "IS-7"
-    sov_heavy_equipment_11_desc:0 "The IS-7 is the most heavily armoured tank in the Soviet arsenal. It cannot be pierced by any ground unit in the game. It has a slightly upgraded gun and retains a very high manouverability. However it comes at cost, a very long to produce."
+    sov_heavy_equipment_11_desc:0 "The IS-7 is the most heavily armoured tank in the Soviet arsenal. It cannot be pierced by any ground unit in the game. It has a slightly upgraded gun and retains a very high manouverability. However it comes at cost, it is quite expensive to produce."
 
     sov_heavy_equipment_12:0 "IS-8"
     sov_heavy_equipment_12_short:0 "IS-8"

--- a/localisation/replace/afo_tanks_l_english.yml
+++ b/localisation/replace/afo_tanks_l_english.yml
@@ -1364,7 +1364,7 @@
     tank_sov_heavy_chassis_6_desc:0 "The IS-4 significantly expands the size and armour on the hull. It can only be pierced by the most powerful of anti-tank guns. It is more expensive to produce and provides little improvements in offensive capabilities."
 
     tank_sov_heavy_chassis_7:0 "§W§!IS 7§W§!"
-    tank_sov_heavy_chassis_7_desc:0 "The IS-7 is the most heavily armoured tank in the Soviet arsenal. It cannot be pierced by any ground unit in the game. It has a slightly upgraded gun and retains a very high manouverability. However it comes at cost, a very long to produce."
+    tank_sov_heavy_chassis_7_desc:0 "The IS-7 is the most heavily armoured tank in the Soviet arsenal. It cannot be pierced by any ground unit in the game. It has a slightly upgraded gun and retains a very high manouverability. However it comes at cost, it is quite expensive to produce."
 
     tank_sov_heavy_chassis_8:0 "§W§!IS 8§W§!"
     tank_sov_heavy_chassis_8_desc:0 "The IS-8 provides a significant anti-tank improvement to the 122mm that has remained unchanged since the IS-2. It is heavily armoured and capable of dealing large amounts of damage."


### PR DESCRIPTION
- Lend lease decisions for US Ai --> Sov Ai for more historical lend lease (planes especially)
- Gave the Soviet AI a meta focustree order
- SOV AI will now do tier 3 land doctrines when it has the 99% bonuses instead of waiting until it has 105xp
- Made a duplicate of the Air reform decision just for the soviet AI so it can actually reform its airforce because otherwise it wastes all its XP on overpriced doctrines (Ai will do factor doesnt work on Air doctrines so you cant stop the AI from doing it)
- Nerfed the Demobilization decisions, 10 Mils > 3 Civs instead of 10 > 5
- Removed the Penalties from Emergency factory conversion so it isnt completely useless
- Added a Decision for the Soviet AI similiar to Forced conscription but its 1 tank division every 20 days, can be stopped by simply strat bombing the urals as germany
- Buffed Forced Conscription
- Various US AI fixes for a sealion scenario (stops the US from retooling its entire civ industry while still building up)

- [x] Balance
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] AI change (change to any sort of AI behavior)


- [x] I HAVE TESTED THESE CHANGES BY RUNNING THE GAME AND VERIFYING THEY WORK AS INTENDED.

## Screenshots (if appropriate, e.g. map changes, tech tree changes, etc.):
