### PR TITLE
Update usa.txt

### DIFF
--- a/common/national_focus/usa.txt
+++ b/common/national_focus/usa.txt
@@ -247,7 +247,7 @@ focus_tree = {
 
 		available = {
 			has_government = democratic
-			has_country_leader = { ruling_only = yes name = "Franklin Delano Roosevelt" }
+			has_country_leader = { ruling_only = yes character = USA_franklin_delano_roosevelt }
 			congress_medium_support_trigger = yes
 		}
 
@@ -285,7 +285,7 @@ focus_tree = {
 
 		available = {
 			has_government = democratic
-			has_country_leader = { ruling_only = yes name = "Franklin Delano Roosevelt" }
+			has_country_leader = { ruling_only = yes character = USA_franklin_delano_roosevelt }
 			congress_high_support_trigger = yes
 		}
 
@@ -327,7 +327,7 @@ focus_tree = {
 
 		available = {
 			has_government = democratic
-			has_country_leader = { ruling_only = yes name = "Franklin Delano Roosevelt" }
+			has_country_leader = { ruling_only = yes character = USA_franklin_delano_roosevelt }
 			congress_massive_support_trigger = yes
 		}
 
@@ -372,7 +372,7 @@ focus_tree = {
 
 		available = {
 			has_government = democratic
-			has_country_leader = { ruling_only = yes name = "Franklin Delano Roosevelt" }
+			has_country_leader = { ruling_only = yes character = USA_franklin_delano_roosevelt }
 		}
 
 		bypass = {
@@ -971,7 +971,7 @@ focus_tree = {
 
 		available = {
 			has_government = democratic
-			has_country_leader = { ruling_only = yes name = "Franklin Delano Roosevelt" }
+			has_country_leader = { ruling_only = yes character = USA_franklin_delano_roosevelt }
 			NOT = {
 				has_country_flag = USA_judicial_reform_fail
 			}
@@ -1008,7 +1008,7 @@ focus_tree = {
 
 		available = {
 			has_government = democratic
-			has_country_leader = { ruling_only = yes name = "Franklin Delano Roosevelt" }
+			has_country_leader = { ruling_only = yes character = USA_franklin_delano_roosevelt }
 			congress_high_support_trigger = yes
 		}
 
@@ -1040,7 +1040,7 @@ focus_tree = {
 
 		available = {
 			has_government = democratic
-			has_country_leader = { ruling_only = yes name = "Franklin Delano Roosevelt" }
+			has_country_leader = { ruling_only = yes character = USA_franklin_delano_roosevelt }
 			congress_massive_support_trigger = yes
 		}
 
@@ -1078,7 +1078,7 @@ focus_tree = {
 
 		available = {
 			has_government = democratic
-			has_country_leader = { ruling_only = yes name = "Franklin Delano Roosevelt" }
+			has_country_leader = { ruling_only = yes character = USA_franklin_delano_roosevelt }
 			congress_high_support_trigger = yes
 		}
 
@@ -1213,7 +1213,7 @@ focus_tree = {
 
 		available = {
 			has_government = democratic
-			has_country_leader = { ruling_only = yes name = "Franklin Delano Roosevelt" }
+			has_country_leader = { ruling_only = yes character = USA_franklin_delano_roosevelt }
 			congress_high_support_trigger = yes
 		}
 
@@ -1250,7 +1250,7 @@ focus_tree = {
 
 		available = {
 			has_government = democratic
-			has_country_leader = { ruling_only = yes name = "Franklin Delano Roosevelt" }
+			has_country_leader = { ruling_only = yes character = USA_franklin_delano_roosevelt }
 			congress_high_support_trigger = yes
 		}
 
@@ -1400,7 +1400,7 @@ focus_tree = {
 
 		available = {
 			has_government = democratic
-			has_country_leader = { ruling_only = yes name = "Franklin Delano Roosevelt" }
+			has_country_leader = { ruling_only = yes character = USA_franklin_delano_roosevelt }
 			congress_high_support_trigger = yes
 		}
 
@@ -1432,7 +1432,7 @@ focus_tree = {
 
 		available = {
 			has_government = democratic
-			has_country_leader = { ruling_only = yes name = "Franklin Delano Roosevelt" }
+			has_country_leader = { ruling_only = yes character = USA_franklin_delano_roosevelt }
 			congress_high_support_trigger = yes
 		}
 


### PR DESCRIPTION
Fixed an issue where "NF" could not advance.


## Description
<!--- Describe your changes in detail using the bulleted list button in the top right. -->


## Motivation and Context
Since the character name is specified in the NF conditions, if you introduce a translation mod, you will not be able to clear the NF conditions and you will not be able to proceed.
This problem is solved by changing to specify the character instead of specifying the character name.


## How has this been tested?
I directly changed the WA file I'm using now and started the game. Then I played normally and confirmed that there were no problems.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Equipment change (non-breaking change of equipment stats/year)
- [ ] New feature (non-breaking content/mechanic which adds functionality)
- [ ] Map change (change to states, provinces, air zones, sea zones, etc.)
- [ ] Balance change (change entirely for the sake of balance purposes)
- [ ] Localization change (change just to the text)
- [ ] AI change (change to any sort of AI behavior)
- [x] Art/GUI change (change just to gfx/art/GUI/etc.)
- [ ] Save breaking change (fix or feature that would cause existing save games to break)
- [ ] Documentation/Administrative/Github update


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] My change requires a change to the roadmap.
- [ ] If the above is true, have updated the roadmap.
- [ ] My change requires a change to the spreadsheet(s).
- [ ] If the above is true, I have updated the spreadsheet(s).
- [ ] My change alters the balance of the mod.
- [ ] If the above is true, I have received approval for the balance change.
- [x] My code follows the code style of this project (neat, optimized, readable, etc.)
- [x] I HAVE TESTED THESE CHANGES BY RUNNING THE GAME AND VERIFYING THEY WORK AS INTENDED.

## Screenshots (if appropriate, e.g. map changes, tech tree changes, etc.):
