### PR TITLE
Halved modifiers for bombing modifiers for Concentrated and dispersed

### DIFF
--- a/common/technologies/industry.txt
+++ b/common/technologies/industry.txt
@@ -298,7 +298,7 @@ technologies = {
 		industrial_capacity_factory = 0.1
 		industrial_capacity_dockyard = 0.05
 		equipment_conversion_speed = -0.25
-		industry_air_damage_factor = 0.3
+		industry_air_damage_factor = 0.15
 		line_change_production_efficiency_factor = -0.05
 		production_lack_of_resource_penalty_factor = 0.1
 		global_building_slots_factor = 0.10
@@ -344,7 +344,7 @@ technologies = {
 		industrial_capacity_factory = -0.1
 		industrial_capacity_dockyard = -0.05
 		equipment_conversion_speed = 0.25
-		industry_air_damage_factor = -0.3
+		industry_air_damage_factor = -0.15
 		line_change_production_efficiency_factor = 0.05
 		production_lack_of_resource_penalty_factor = -0.1
 


### PR DESCRIPTION
- Prevents players from getting -96% bombing damage reduction