### PR TITLE
Strike force gives some supremacy

### DIFF
--- a/common/defines/05_defines.lua
+++ b/common/defines/05_defines.lua
@@ -615,7 +615,7 @@ NDefines.NNavy.AGGRESSION_SETTINGS_VALUES = { 										-- ships will use this v
 NDefines.NNavy.MISSION_SUPREMACY_RATIOS = { 										-- supremacy multipliers for different mission types
         0.0, -- HOLD
         1.0, -- PATROL
-        0.0, -- STRIKE FORCE
+        0.18, -- STRIKE FORCE
         0.5, -- CONVOY RAIDING
         0.5, -- CONVOY ESCORT
         0.3, -- MINES PLANTING


### PR DESCRIPTION
Strike force now gives supremacy but green air and naval intelligence can still overcome it relatively easily, this fixes issues where players dont have to use their Air force or build any ships in SP to sealion.

80 Ships with green air will still have naval supremacy over 200 ships even with 100% mines.