### PR TITLE
AA rebalancing

### DIFF
--- a/common/buildings/00_buildings.txt
+++ b/common/buildings/00_buildings.txt
@@ -61,12 +61,12 @@ buildings = {
 
 	anti_air_building = {
 		show_on_map = 3
-		base_cost = 4000
+		base_cost = 1200
 		icon_frame = 9
 		anti_air = yes
 		disabled_in_dmz = yes
 		air_defence = 1
-		max_level = 3 # This is the max unlock level
+		max_level = 10 # This is the max unlock level
 		damage_factor = 0.1
 		value = 1
 		infrastructure_construction_effect = yes

--- a/common/defines/05_defines.lua
+++ b/common/defines/05_defines.lua
@@ -159,7 +159,7 @@ NDefines.NProduction.LICENSE_EQUIPMENT_BASE_SPEED = -0.25							-- base MIC spee
 NDefines.NProduction.LICENSE_EQUIPMENT_SPEED_NOT_FACTION = -0.25					-- MIC speed modifier for licensed equipment for not being in faction
 NDefines.NProduction.LICENSE_EQUIPMENT_TECH_SPEED_PER_YEAR = 0						-- MIC speed modifier for licensed equipment for each year of difference between actual and latest equipment
 NDefines.NProduction.LICENSE_EQUIPMENT_TECH_SPEED_MAX_YEARS = 1						-- Maximum years for MIC speed modifier
-	
+
 NDefines.NProduction.CAPITULATE_STOCKPILES_RATIO = 0.7 								-- How much equipment from deployed divisions will be transferred on capitulation
 
 NDefines.NProduction.MAX_EQUIPMENT_RESOURCES_NEED = 6 								-- Max number of different strategic resources an equipment can be dependent on.
@@ -457,7 +457,7 @@ NDefines.NAir.AIR_WING_ATTACK_LOGISTICS_INFRA_DAMAGE_SPILL_FACTOR = 0.0 			-- Po
 NDefines.NAir.CAS_NIGHT_ATTACK_FACTOR = 0.1						                    -- CAS damaged get multiplied by this in land combats at night
 NDefines.NAir.ANTI_AIR_MAXIMUM_DAMAGE_REDUCTION_FACTOR = 0.50 						-- Maximum damage reduction factor applied to incoming air attacks against units with AA.
 
-NDefines.NAir.BOMBING_TARGETING_RANDOM_FACTOR = 0.25								-- % of picking the wrong target
+NDefines.NAir.BOMBING_TARGETING_RANDOM_FACTOR = 0.8									-- % of picking the wrong target
 NDefines.NAir.AIR_WING_BOMB_DAMAGE_FACTOR = 3										-- Used to balance the damage done while bombing.
 NDefines.NAir.BOMBING_PROV_BUILD_PRIO_SCALE = 2										-- Scale of the selected priority for provincial buildings
 NDefines.NAir.BOMBING_STATE_BUILD_PRIO_SCALE = 2									-- Scale of the selected priority for state buildings

--- a/common/defines/05_defines.lua
+++ b/common/defines/05_defines.lua
@@ -456,6 +456,7 @@ NDefines.NAir.AIR_WING_ATTACK_LOGISTICS_INFRA_DAMAGE_SPILL_FACTOR = 0.0 			-- Po
 
 NDefines.NAir.CAS_NIGHT_ATTACK_FACTOR = 0.1						                    -- CAS damaged get multiplied by this in land combats at night
 NDefines.NAir.ANTI_AIR_MAXIMUM_DAMAGE_REDUCTION_FACTOR = 0.50 						-- Maximum damage reduction factor applied to incoming air attacks against units with AA.
+NDefines.NAir.AA_INDUSTRY_AIR_DAMAGE_FACTOR = -0.036									-- 5x levels = 60% defense from bombing
 
 NDefines.NAir.BOMBING_TARGETING_RANDOM_FACTOR = 0.8									-- % of picking the wrong target
 NDefines.NAir.AIR_WING_BOMB_DAMAGE_FACTOR = 3										-- Used to balance the damage done while bombing.

--- a/common/technologies/artillery_ger.txt
+++ b/common/technologies/artillery_ger.txt
@@ -2168,7 +2168,7 @@ technologies = {
 
 		enable_building = {
 			building = anti_air_building
-			level = 1
+			level = 4
 		}
 
 		#static_anti_air_damage_factor = 0.1
@@ -2217,7 +2217,7 @@ technologies = {
 
 		enable_building = {
 			building = anti_air_building
-			level = 2
+			level = 7
 		}
 
 		#static_anti_air_damage_factor = 0.1
@@ -2358,7 +2358,7 @@ technologies = {
 
 		enable_building = {
 			building = anti_air_building
-			level = 3
+			level = 10
 		}
 
 		#static_anti_air_damage_factor = 0.1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title ABOVE. -->


## Description
<!--- Describe your changes in detail using the bulleted list button in the top right. -->
- Bomber building targeting accuracy reduced to 20% from 75% (vanilla value)
- AA max level increased to level 10
- AA cost reduced to 1200 (level 10 AA is as expensive as level 3 was before)
- Factory bomb vulnerability per AA level decreased to 3.6% (keeps same max vulnerability as level 3 got before)
- AA building techs changed to unlock level 4, level 7, and then level 10 respectively

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue or bug report, please link or reference it here. -->
- AA was too weak
- Did not shoot down enough bombers
- Was not granular enough with respect to factory bomb vulnerability

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of how you ran the game and ensured your changes work as intended without breaking anything. -->
- AA tests yield more bombers shot down, more granular AA destruction
- AA tests yield less bomber accuracy


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Equipment change (non-breaking change of equipment stats/year)
- [ ] New feature (non-breaking content/mechanic which adds functionality)
- [ ] Map change (change to states, provinces, air zones, sea zones, etc.)
- [x] Balance change (change entirely for the sake of balance purposes)
- [ ] Localization change (change just to the text)
- [ ] AI change (change to any sort of AI behavior)
- [ ] Art/GUI change (change just to gfx/art/GUI/etc.)
- [ ] Save breaking change (fix or feature that would cause existing save games to break)
- [ ] Documentation/Administrative/Github update


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My change requires a change to the roadmap.
- [x] If the above is true, have updated the roadmap.
- [ ] My change requires a change to the spreadsheet(s).
- [ ] If the above is true, I have updated the spreadsheet(s).
- [x] My change alters the balance of the mod.
- [x] If the above is true, I have received approval for the balance change.
- [x] My code follows the code style of this project (neat, optimized, readable, etc.)
- [x] I HAVE TESTED THESE CHANGES BY RUNNING THE GAME AND VERIFYING THEY WORK AS INTENDED.

## Screenshots (if appropriate, e.g. map changes, tech tree changes, etc.):
