### PR TITLE
Danzig or war

### DIFF
--- a/common/decisions/GER.txt
+++ b/common/decisions/GER.txt
@@ -3990,7 +3990,6 @@ war_measures = {
 			has_government = fascism
 			has_army_experience > 99
 			command_power > 99
-			has_army_manpower = { size > 1599999 }
 		}
 		visible = {
 			has_war = no
@@ -4001,6 +4000,18 @@ war_measures = {
 			}
 		}
 		complete_effect = {
+			custom_effect_tooltip = GER_prepare_for_a_european_war_stab_tt
+			if = {
+				limit = {
+					NOT = {
+						has_army_manpower = { size > 1599999 }
+					}
+				}
+				set_variable = { var = GER_Wehrmacht_stability value = -5 }
+				set_variable = { var = GER_Wehrmacht_attitude value = 45 }
+				GER_political_instability_update_effect = yes
+			}
+					
 			army_experience = -100
 			add_command_power = -100
 			custom_effect_tooltip = prepare_for_a_european_war_tt

--- a/common/decisions/GER.txt
+++ b/common/decisions/GER.txt
@@ -3990,6 +3990,7 @@ war_measures = {
 			has_government = fascism
 			has_army_experience > 99
 			command_power > 99
+			has_army_manpower = { size > 1599999 }
 		}
 		visible = {
 			has_war = no
@@ -4001,16 +4002,16 @@ war_measures = {
 		}
 		complete_effect = {
 			custom_effect_tooltip = GER_prepare_for_a_european_war_stab_tt
-			if = {
-				limit = {
-					NOT = {
-						has_army_manpower = { size > 1599999 }
-					}
-				}
-				set_variable = { var = GER_Wehrmacht_stability value = -5 }
-				set_variable = { var = GER_Wehrmacht_attitude value = 45 }
-				GER_political_instability_update_effect = yes
-			}
+			#if = {
+			#	limit = {
+			#		NOT = {
+			#			has_army_manpower = { size > 1599999 }
+			#		}
+			#	}
+			#	set_variable = { var = GER_Wehrmacht_stability value = -5 }
+			#	set_variable = { var = GER_Wehrmacht_attitude value = 45 }
+			#	GER_political_instability_update_effect = yes
+			#}
 					
 			army_experience = -100
 			add_command_power = -100

--- a/common/decisions/GER.txt
+++ b/common/decisions/GER.txt
@@ -3990,6 +3990,7 @@ war_measures = {
 			has_government = fascism
 			has_army_experience > 99
 			command_power > 99
+			has_army_manpower = { size > 1599999 }
 		}
 		visible = {
 			has_war = no

--- a/common/ideas/germany.txt
+++ b/common/ideas/germany.txt
@@ -1925,7 +1925,7 @@ ideas = {
 
 		GER_barbarossa_preparation = {
 			allowed = {
-				NOT = { has_war_with = SOV }
+				always = no
 			}
 
 			allowed_civil_war = {
@@ -1933,6 +1933,10 @@ ideas = {
 			}
 
 			removal_cost = -1
+
+			cancel = {
+				has_war_with = SOV
+			}
 
 			modifier = {
 	        	production_factory_efficiency_gain_factor = 0.25
@@ -1945,11 +1949,11 @@ ideas = {
 				production_speed_rail_way_factor = 0.25
 	        }
 
-			targeted_modifier = {
-				tag = SOV
-				attack_bonus_against = -0.2
-				defense_bonus_against = -0.2
-			}
+			#targeted_modifier = {
+			#	tag = SOV
+			#	attack_bonus_against = -0.2
+			#	defense_bonus_against = -0.2
+			#}
 		}
 
 		GER_barbarossa = {

--- a/common/ideas/germany.txt
+++ b/common/ideas/germany.txt
@@ -1944,6 +1944,12 @@ ideas = {
 				production_speed_supply_node_factor = 0.25
 				production_speed_rail_way_factor = 0.25
 	        }
+
+			targeted_modifier = {
+				tag = SOV
+				attack_bonus_against = -0.2
+				defense_bonus_against = -0.2
+			}
 		}
 
 		GER_barbarossa = {

--- a/common/national_focus/germany.txt
+++ b/common/national_focus/germany.txt
@@ -6140,7 +6140,7 @@ focus_tree = {
 			AUS = {
 				fascism > 0.6
 			}
-			has_army_manpower = { size > 749999 }
+			has_army_manpower = { size > 899999 }
 			NOT = { has_idea = rhineland_challenge_met }
 			if = {
 				limit = {

--- a/common/national_focus/germany.txt
+++ b/common/national_focus/germany.txt
@@ -7265,7 +7265,7 @@ focus_tree = {
 		will_lead_to_war_with = POL
 		available = {
 			is_puppet = no
-			has_army_manpower = { size > 1399999 } #115 div
+			has_army_manpower = { size > 1499999 } #120 div
 			#Make custom trigger tooltip here
 			OR = {
 				AND = {

--- a/common/national_focus/germany.txt
+++ b/common/national_focus/germany.txt
@@ -7265,7 +7265,7 @@ focus_tree = {
 		will_lead_to_war_with = POL
 		available = {
 			is_puppet = no
-			has_army_manpower = { size > 1199999 } #100 div
+			has_army_manpower = { size > 1399999 } #115 div
 			#Make custom trigger tooltip here
 			OR = {
 				AND = {

--- a/localisation/replace/afo_decisions_l_english.yml
+++ b/localisation/replace/afo_decisions_l_english.yml
@@ -2265,7 +2265,7 @@ rom_hun_border_conflict_won:0 "Experience from the border clash in Korea:"
    GER_ports_boom_normandy:0 "Blow up Normandy Ports"
    GER_ports_boom_britanny:0 "Blow up Britanny Ports"
    GER_ports_boom_western_france:0 "Blow up Ports in Western France"
-   GER_ports_boom_toulon:0 "Blow up Toulon Ports
+   GER_ports_boom_toulon:0 "Blow up Toulon Ports"
 
    GER_prepare_for_a_european_war_stab_tt:1 "If we do not have at least §G1.6m Men in the field§! the £faction_ger_wehrmacht §YWehrmacht§! becomes §RViolent§! and reduces §YStability§! by §R25%§!"
 

--- a/localisation/replace/afo_decisions_l_english.yml
+++ b/localisation/replace/afo_decisions_l_english.yml
@@ -2265,7 +2265,9 @@ rom_hun_border_conflict_won:0 "Experience from the border clash in Korea:"
    GER_ports_boom_normandy:0 "Blow up Normandy Ports"
    GER_ports_boom_britanny:0 "Blow up Britanny Ports"
    GER_ports_boom_western_france:0 "Blow up Ports in Western France"
-   GER_ports_boom_toulon:0 "Blow up Toulon Ports"
+   GER_ports_boom_toulon:0 "Blow up Toulon Ports
+
+   GER_prepare_for_a_european_war_stab_tt:1 "If we do not have at least §G1.6m Men in the field§! the £faction_ger_wehrmacht §YWehrmacht§! becomes §RViolent§! and reduces §YStability§! by §R25%§!"
 
    GER_increase_working_hours_tt:0 "Modify the §YReorganized Industry§! by\nFactory Output: §G+5%§! \nWeekly War Support: §R-0.10%§! \n\n"
    GER_stricter_rations_tt:0 "Modify the §YReorganized Industry§! by\nConsumer Goods: §G-1%§! \nWeekly War Support: §R-0.10%§! \n\n"


### PR DESCRIPTION

## Description
- Increased Danzig or War manpower requirement from 1.2 to 1.4m
- Prepare for a European war requires 1.6m men deployed


## Motivation and Context
- Rushing the focuses (which is easily doable) and just doing prepare for a european war lets a player attack the soviets in 1939, a player should have to invest in his land army to be able to do prepare for a european war and danzig or war should not be rushable with a bad build 



- [x] Balance change (change entirely for the sake of balance purposes)


- [x] My change alters the balance of the mod.


