### PR TITLE
removed non existing pre NSB defines and replace them with new ones

### DIFF
--- a/common/defines/05_defines.lua
+++ b/common/defines/05_defines.lua
@@ -276,7 +276,7 @@ NDefines.NMilitary.MAX_DIVISION_SUPPORT_HEIGHT = 5									-- Max height of supp
 
 NDefines.NMilitary.UNIT_LEADER_ASSIGN_TRAIT_COST = 5								-- cost to assign a new trait to a unit leader
 NDefines.NMilitary.ARMY_STRATEGIC_DEPLOYMENT_FUEL_MULT = 0.0						-- fuel consumption ratio while doing strategic deployment
-NDefines.NMilitary.STRATEGIC_SPEED_INFRA_BASE = 2.0
+NDefines.NMilitary.STRATEGIC_SPEED_INFRA_BASE = 3.0
 NDefines.NMilitary.STRATEGIC_SPEED_INFRA_MAX = 5.0
 NDefines.NMilitary.STRATEGIC_SPEED_RAIL_BASE = 15.0
 NDefines.NMilitary.STRATEGIC_SPEED_RAIL_MAX = 25.0

--- a/common/defines/05_defines.lua
+++ b/common/defines/05_defines.lua
@@ -276,9 +276,10 @@ NDefines.NMilitary.MAX_DIVISION_SUPPORT_HEIGHT = 5									-- Max height of supp
 
 NDefines.NMilitary.UNIT_LEADER_ASSIGN_TRAIT_COST = 5								-- cost to assign a new trait to a unit leader
 NDefines.NMilitary.ARMY_STRATEGIC_DEPLOYMENT_FUEL_MULT = 0.0						-- fuel consumption ratio while doing strategic deployment
-NDefines.NMilitary.STRATEGIC_SPEED_BASE = 2.0                 						-- Speed of strategic redeployment
-NDefines.NMilitary.STRATEGIC_INFRA_SPEED = 18.0                  					-- Max of additional speed gained trouh=gh level for strategic redeployment per infra
-
+NDefines.NMilitary.STRATEGIC_SPEED_INFRA_BASE = 2.0
+NDefines.NMilitary.STRATEGIC_SPEED_INFRA_MAX = 5.0
+NDefines.NMilitary.STRATEGIC_SPEED_RAIL_BASE = 15.0
+NDefines.NMilitary.STRATEGIC_SPEED_RAIL_MAX = 25.0
 --NDefines.NMilitary.PLAN_EXECUTE_CAREFUL_LIMIT = 10								-- When looking for an attach target, this score limit is required in the battle plan to consider province for attack
 --NDefines.NMilitary.PLAN_EXECUTE_CAREFUL_MAX_FORT = 9								-- If execution mode is set to careful, units will not attack provinces with fort levels greater than or equal to this
 


### PR DESCRIPTION
We were still using strategic redeployment defines from 1,5 years ago, they dont exist anymore.

Our old strat redeploy speed used to be 2.0 pre NSB, i made the non railway strat redeploy speed 3.0 kph (Infantry base speed in WA), (vanilla and what we have been using because no one noticed is 5.0)

Railways strat redeploy speed is unchanged from vanilla.