### PR TITLE
reduced mobilization speed

### DIFF
--- a/common/defines/05_defines.lua
+++ b/common/defines/05_defines.lua
@@ -109,7 +109,7 @@ NDefines.NCountry.NUM_DAYS_TO_FULLY_DELETE_STOCKPILED_EQUIPMENT = 365				-- time
 NDefines.NCountry.SPECIAL_FORCES_CAP_BASE = 0.02									-- Max ammount of special forces battalions is total number of non-special forces battalions multiplied by this and modified by a country modifier
 NDefines.NCountry.SPECIAL_FORCES_CAP_MIN = 10										-- You can have a minimum of this many special forces battalions, regardless of the number of non-special forces battalions you have, this can also be modified by a country modifier
 
-NDefines.NCountry.BASE_MOBILIZATION_SPEED = 0.02									-- Base speed of manpower mobilization  #in 1/1000 of 1 %
+NDefines.NCountry.BASE_MOBILIZATION_SPEED = 0.01									-- Base speed of manpower mobilization  #in 1/1000 of 1 %
 
 NDefines.NCountry.WAR_SUPPORT_TENSION_IMPACT = 0									-- Total impact of world tension
 NDefines.NCountry.STATE_VALUE_NON_CORE_STATE_FRACTION = 1.0							-- If a state is not a core we assume we will get 50% of the factory slots


### PR DESCRIPTION
The Vanilla define is 0.01, the 0.02 value we have been using lets you mobilize large amounts of manpower (millions) within weeks, something which is very unrealistic and also makes mobilization speed modifiers pointless.



- [x] Balance change (change entirely for the sake of balance purposes)



