### PR TITLE
Italy needs to reform its army first

### DIFF
--- a/common/ideas/army_spirits.txt
+++ b/common/ideas/army_spirits.txt
@@ -489,6 +489,12 @@ ideas = {
 					has_government = neutrality
 					has_government = fascism
 				}
+				if = {
+					limit = {
+						tag = ITA
+					}
+					has_country_flag = adequate_army
+				}
 				custom_trigger_tooltip = {
 					tooltip = army_spirits_army_tt
 					OR = {


### PR DESCRIPTION
It is weird that italy can have professional officer corps before having reformed its army.