### PR TITLE
spirits

### DIFF
--- a/common/ideas/air_spirits.txt
+++ b/common/ideas/air_spirits.txt
@@ -673,6 +673,8 @@ ideas = {
 			}
 			modifier = {
 				air_nav_efficiency = 0.15
+				sortie_efficiency = 0.05
+				naval_strike_targetting_factor = 0.03
 				mines_planting_by_air_factor = 0.1
 				mines_sweeping_by_air_factor = 0.1
 				air_wing_xp_loss_when_killed_factor = 0.1

--- a/common/ideas/army_spirits.txt
+++ b/common/ideas/army_spirits.txt
@@ -543,7 +543,7 @@ ideas = {
 				}
 			}
 			modifier = {
-				supply_consumption_factor = 0.04
+				supply_consumption_factor = 0.01
 				equipment_capture_factor = 0.02
 				terrain_penalty_reduction = 0.05
 				unit_engineer_design_cost_factor = -1.0
@@ -1254,7 +1254,7 @@ ideas = {
 				}
 			}
 			modifier = {
-				org_loss_when_moving = -0.15
+				org_loss_when_moving = -0.1
 				army_speed_factor = 0.05
 				choose_preferred_tactics_cost = -15
 				custom_modifier_tooltip = delay_tactic_chance_tt
@@ -1469,15 +1469,6 @@ ideas = {
 				modifier = {
 					factor = 40
 					tag = ENG
-					NOT = {
-						has_country_flag = eng_smoke_fire
-					}
-				}
-
-				modifier = {
-					factor = 0
-					tag = ENG
-					has_country_flag = eng_smoke_fire
 				}
 
 				modifier = {
@@ -1534,6 +1525,7 @@ ideas = {
 				custom_modifier_tooltip = blitz_tactic_chance_tt
 				army_speed_factor = 0.1
 				coordination_bonus = 0.05
+				org_loss_when_moving = -0.05
 				supply_consumption_factor = 0.05
 			}
 			ai_will_do = {
@@ -1581,12 +1573,6 @@ ideas = {
 				}
 
 				modifier = {
-					factor = 40
-					tag = ENG
-					has_country_flag = eng_smoke_fire
-				}
-
-				modifier = {
 					factor = 0
 					OR = {
 						tag = CHI
@@ -1614,7 +1600,7 @@ ideas = {
 				custom_modifier_tooltip = ambush_tactic_chance_tt
 				training_time_factor = 0.2
 				army_org_factor = -0.3
-				army_core_attack_factor = 0.5
+				army_core_attack_factor = 1.0
 				experience_loss_factor = -0.25
 				cas_damage_reduction = 0.4
 				army_speed_factor = 0.2


### PR DESCRIPTION
- Moved some of the reduced org loss from moving from Flexible organization to maneuver warfare so the Generic spirit isnt a better pick than the doctrine specific one
- Made Maritime aviation not completely useless
- Reduced supply consumption penatly of elevated engineering corps because +4% was too much