### PR TITLE
Personality cult: give a discount to all ministers

### DIFF
--- a/common/country_leader/00_traits.txt
+++ b/common/country_leader/00_traits.txt
@@ -1075,6 +1075,11 @@ leader_traits = {
 
 	personality_cult = {
 		random = no
+		foreign_minister_cost_factor = -0.25
+		interior_minister_cost_factor = -0.25
+		economic_minister_cost_factor = -0.25
+		transport_minister_cost_factor = -0.25
+		intelligence_minister_cost_factor = -0.25
 		political_advisor_cost_factor = -0.25
 		high_command_cost_factor = -0.25
 		theorist_cost_factor = -0.25


### PR DESCRIPTION
## Description
* Give a 25% discount to all ministers from personality cult trait

## Motivation and Context
After splitting political advisors into the foreign, interior, etc. this trait was implicitly nerfed.
I think the original purpose of this trait should be fixed and we should give discounts to all ministers.


## How has this been tested?
I tested it during playing for the Soviet Union.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Equipment change (non-breaking change of equipment stats/year)
- [ ] New feature (non-breaking content/mechanic which adds functionality)
- [ ] Map change (change to states, provinces, air zones, sea zones, etc.)
- [x] Balance change (change entirely for the sake of balance purposes)
- [ ] Localization change (change just to the text)
- [ ] AI change (change to any sort of AI behavior)
- [ ] Art/GUI change (change just to gfx/art/GUI/etc.)
- [ ] Save breaking change (fix or feature that would cause existing save games to break)
- [ ] Documentation/Administrative/Github update


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] My change requires a change to the roadmap.
- [ ] If the above is true, have updated the roadmap.
- [ ] My change requires a change to the spreadsheet(s).
- [ ] If the above is true, I have updated the spreadsheet(s).
- [x] My change alters the balance of the mod.
- [ ] If the above is true, I have received approval for the balance change.
- [x] My code follows the code style of this project (neat, optimized, readable, etc.)
- [x] I HAVE TESTED THESE CHANGES BY RUNNING THE GAME AND VERIFYING THEY WORK AS INTENDED.

## Screenshots (if appropriate, e.g. map changes, tech tree changes, etc.):
