### PR TITLE
changed 2 traits

### DIFF
--- a/common/unit_leader/00_traits.txt
+++ b/common/unit_leader/00_traits.txt
@@ -864,7 +864,7 @@ leader_traits = {
 			logistics_skill_level > 3
 		}
 		field_marshal_modifier = {
-			supply_consumption_factor = -0.10
+			supply_consumption_factor = -0.05
 		}
 		enable_ability = extra_suplies
 		ai_will_do = {
@@ -882,7 +882,7 @@ leader_traits = {
 		}
 		cost = 500
 		field_marshal_modifier = {
-			org_loss_when_moving = -0.2
+			org_loss_when_moving = -0.05
 		}
 
 		attack_skill = 1


### PR DESCRIPTION
- One single trait giving -20% org loss on moving is way too much considering how many other things there are that do the same, one single trait also shouldnt provide more than a doctrine or spirit.

- -10% supply consumption for an entire army group from a single trait is also an insane amount of supply reduction on top of doctrines/spirits/general skills/FM skills