### PR TITLE
Add description for sudetenland_acquired flag

### DIFF
--- a/common/national_focus/soviet.txt
+++ b/common/national_focus/soviet.txt
@@ -8673,7 +8673,7 @@ focus_tree = {
 				AND = {
 					has_completed_focus = SOV_anti_fascist_policies
 					GER = {
-						has_country_flag = sudetenland_acquired
+						has_country_flag = GER_sudetenland_acquired_flag
 					}
 				}
 			}

--- a/events/Germany.txt
+++ b/events/Germany.txt
@@ -2894,7 +2894,7 @@ country_event = {
 		GER = { transfer_state = 69 }
 		74 = { add_core_of = GER }
 		GER = { transfer_state = 74 }
-		set_country_flag = sudetenland_acquired
+		set_country_flag = GER_sudetenland_acquired_flag
 		add_stability = 0.05
 		play_peace_in_our_time_effect = yes
 		USA = {

--- a/localisation/replace/afo_focus_l_english.yml
+++ b/localisation/replace/afo_focus_l_english.yml
@@ -5813,6 +5813,8 @@
   GER_demand_sudetenland_flag:0 "Has completed focus §YDemand Sudetenland§!"
   GER_demand_sudetenland_flag_tt:0 "Current days are: [?GER_demand_sudetenland_flag:days|Y0]"
 
+  GER_sudetenland_acquired_flag:0 "Has acquired §YSudetenland§!"
+
   GER_proclaim_the_axis_powers:0 "Proclaim the Axis Powers"
   GER_proclaim_the_axis_powers_desc:0 ""There is no doubt that in this moment the axis of European history passes through Berlin""
 


### PR DESCRIPTION
## Description
Add description for sudetenland_acquired flag

## Motivation and Context
Cosmetic change

## Screenshots (if appropriate, e.g. map changes, tech tree changes, etc.):
Before:
<img width="228" alt="sudetenland_before" src="https://user-images.githubusercontent.com/6647853/235342879-f594ab0f-a841-4dde-ba30-6cb1864b9287.png">
After:
<img width="188" alt="sudetenland_after" src="https://user-images.githubusercontent.com/6647853/235342876-a4f86719-29de-448b-a0de-42b8778b72e2.png">
