### PR TITLE
Give discount to light support tanks in support tank manufacturer

### DIFF
--- a/common/country_leader/00_traits.txt
+++ b/common/country_leader/00_traits.txt
@@ -6873,6 +6873,9 @@ leader_traits = {
 	support_tank_manufacturer = {
 		random = no
 		equipment_bonus = {
+			light_tank_support_chassis = {
+				build_cost_ic = -0.1 instant = yes
+			}
 			medium_tank_support_chassis = {
 				build_cost_ic = -0.1 instant = yes
 			}


### PR DESCRIPTION
## Description
FRA Renault tank manufacturer has support tank manufacturer traits and gives discounts only to medium support tanks. However, 
FRA doesn't have medium support tanks, it has light support tanks (Renault R35, R40, and AMX40), so this discount is not applied to these tanks. I believe this is an omission and Renault tank manufacturer (and any other support tank manufacturer) should give a discount to light support tanks as well.
This is a very small buff to FRA and makes the behavior of the Renault tank manufacturer more logical.

## Motivation and Context
This change fixes Renault tank manufacturer and gives production discounts to Renault R35/R40 and AMX40 tanks, which are light support tanks.

## Types of changes
- [x] Balance change (change entirely for the sake of balance purposes)

## Checklist:
- [ ] My change requires a change to the roadmap.
- [ ] If the above is true, have updated the roadmap.
- [ ] My change requires a change to the spreadsheet(s).
- [ ] If the above is true, I have updated the spreadsheet(s).
- [x] My change alters the balance of the mod.
- [x] If the above is true, I have received approval for the balance change.
- [x] My code follows the code style of this project (neat, optimized, readable, etc.)
- [x] I HAVE TESTED THESE CHANGES BY RUNNING THE GAME AND VERIFYING THEY WORK AS INTENDED.
