### PR TITLE
hardcode province ids on coastline without guerilla

### DIFF
--- a/common/national_focus/china_nationalist.txt
+++ b/common/national_focus/china_nationalist.txt
@@ -8131,9 +8131,10 @@ focus_tree = {
 				set_state_flag = PRC_guerilla_warfare_flag
 			}
 			hidden_effect = {
+				# Leizhou
 				if = {
 					limit = {
-						596 = {
+						931 = {
 							CONTROLLER = {
 								OR = {
 									is_in_faction_with = ROOT
@@ -8142,21 +8143,26 @@ focus_tree = {
 							}
 						}
 					}
-					596 = {
+					931 = {
 						remove_province_modifier = {
 							static_modifiers = {
 								guerilla_operations
 							}
 							province = {
-								id = 9974
-								id = 1055
+								id = 4160
+								id = 7135
+								id = 4023
+								id = 11963
+								id = 1018
+								id = 10004
 							}
 						}
 					}
 				}
-				if = {
+				# Hainan
+				if = {	
 					limit = {
-						595 = {
+						591 = {
 							CONTROLLER = {
 								OR = {
 									is_in_faction_with = ROOT
@@ -8165,40 +8171,22 @@ focus_tree = {
 							}
 						}
 					}
-					595 = {
+					591 = {
 						remove_province_modifier = {
 							static_modifiers = {
 								guerilla_operations
 							}
 							province = {
-								id = 4196
-								id = 7071
+								id = 1070
+								id = 11990
+								id = 994
+								id = 11963
+								id = 1038
 							}
 						}
 					}
 				}
-				if = {
-					limit = {
-						593 = {
-							CONTROLLER = {
-								OR = {
-									is_in_faction_with = ROOT
-									tag = ROOT
-								}
-							}
-						}
-					}
-					593 = {
-						remove_province_modifier = {
-							static_modifiers = {
-								guerilla_operations
-							}
-							province = {
-								id = 9938
-							}
-						}
-					}
-				}
+				# Guangzhou
 				if = {
 					limit = {
 						592 = {
@@ -8216,11 +8204,186 @@ focus_tree = {
 								guerilla_operations
 							}
 							province = {
+								id = 7039
+								id = 9963
+								id = 11938
 								id = 1047
+								id = 7052
 							}
 						}
 					}
 				}
+				# Guangdong
+				if = {
+					limit = {
+						594 = {
+							CONTROLLER = {
+								OR = {
+									is_in_faction_with = ROOT
+									tag = ROOT
+								}
+							}
+						}
+					}
+					594 = {
+						remove_province_modifier = {
+							static_modifiers = {
+								guerilla_operations
+							}
+							province = {
+								id = 7008
+								id = 4050
+								id = 7067
+								id = 9978
+								id = 9938
+							}
+						}
+					}
+				}
+				# Fujian
+				if = {
+					limit = {
+						595 = {
+							CONTROLLER = {
+								OR = {
+									is_in_faction_with = ROOT
+									tag = ROOT
+								}
+							}
+						}
+					}
+					595 = {
+						remove_province_modifier = {
+							static_modifiers = {
+								guerilla_operations
+							}
+							province = {
+								id = 10093
+								id = 10010
+								id = 7071
+								id = 11986
+								id = 7027
+								id = 13777
+								id = 4196
+								id = 4169
+								id = 10069
+							}
+						}
+					}
+				}
+				# Zhejiang
+				if = {
+					limit = {
+						596 = {
+							CONTROLLER = {
+								OR = {
+									is_in_faction_with = ROOT
+									tag = ROOT
+								}
+							}
+						}
+					}
+					596 = {
+						remove_province_modifier = {
+							static_modifiers = {
+								guerilla_operations
+							}
+							province = {
+								id = 4099
+								id = 1055
+								id = 4013
+								id = 1168
+								id = 10058
+								id = 13776
+								id = 9974
+								id = 7058
+								id = 1096
+								id = 11991
+								id = 7191
+								id = 4042
+							}
+						}
+					}
+				}
+				# Nanjing
+				if = {
+					limit = {
+						598 = {
+							CONTROLLER = {
+								OR = {
+									is_in_faction_with = ROOT
+									tag = ROOT
+								}
+							}
+						}
+					}
+					598 = {
+						remove_province_modifier = {
+							static_modifiers = {
+								guerilla_operations
+							}
+							province = {
+								id = 13369
+								id = 12052
+								id = 10076
+								id = 13370
+							}
+						}
+					}
+				}
+				# N.Shangay
+				if = {
+					limit = {
+						613 = {
+							CONTROLLER = {
+								OR = {
+									is_in_faction_with = ROOT
+									tag = ROOT
+								}
+							}
+						}
+					}
+					613 = {
+						remove_province_modifier = {
+							static_modifiers = {
+								guerilla_operations
+							}
+							province = {
+								id = 7014
+							}
+						}
+					}
+				}
+				# Jiangsu
+				if = {
+					limit = {
+						925 = {
+							CONTROLLER = {
+								OR = {
+									is_in_faction_with = ROOT
+									tag = ROOT
+								}
+							}
+						}
+					}
+					925 = {
+						remove_province_modifier = {
+							static_modifiers = {
+								guerilla_operations
+							}
+							province = {
+								id = 11928
+								id = 4091
+								id = 1089
+								id = 9953
+								id = 12067
+								id = 4031
+								id = 1029
+							}
+						}
+					}
+				}			
+				# Schandong
 				if = {
 					limit = {
 						743 = {
@@ -8243,6 +8406,7 @@ focus_tree = {
 						}
 					}
 				}
+				# Yantai
 				if = {
 					limit = {
 						937 = {
@@ -8265,28 +8429,7 @@ focus_tree = {
 						}
 					}
 				}
-				if = {
-					limit = {
-						596 = {
-							CONTROLLER = {
-								OR = {
-									is_in_faction_with = ROOT
-									tag = ROOT
-								}
-							}
-						}
-					}
-					596 = {
-						remove_province_modifier = {
-							static_modifiers = {
-								guerilla_operations
-							}
-							province = {
-								id = 7191
-							}
-						}
-					}
-				}
+
 				every_enemy_country = {
 					country_event = chi_armor.896
 				}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title ABOVE. -->
Hardcoded prov ids along coast line
But it will be better just make all coaster states gurilla free with simple check:
limit = {
		CONTROLLER = {
			OR = {
				is_in_faction_with = ROOT
				tag = ROOT
			}
		}
		is_coastal  = yes
	}

## Description
<!--- Describe your changes in detail using the bulleted list button in the top right. -->
Remove Guerilla modifiers on coastal tiles

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue or bug report, please link or reference it here. -->
scope of 8.1 roadmap


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of how you ran the game and ensured your changes work as intended without breaking anything. -->
Manually


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Equipment change (non-breaking change of equipment stats/year)
- [ ] New feature (non-breaking content/mechanic which adds functionality)
- [ ] Map change (change to states, provinces, air zones, sea zones, etc.)
- [x] Balance change (change entirely for the sake of balance purposes)
- [ ] Localization change (change just to the text)
- [ ] AI change (change to any sort of AI behavior)
- [ ] Art/GUI change (change just to gfx/art/GUI/etc.)
- [ ] Save breaking change (fix or feature that would cause existing save games to break)
- [ ] Documentation/Administrative/Github update


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] My change requires a change to the roadmap.
- [ ] If the above is true, have updated the roadmap.
- [ ] My change requires a change to the spreadsheet(s).
- [ ] If the above is true, I have updated the spreadsheet(s).
- [ ] My change alters the balance of the mod.
- [ ] If the above is true, I have received approval for the balance change.
- [x] My code follows the code style of this project (neat, optimized, readable, etc.)
- [x] I HAVE TESTED THESE CHANGES BY RUNNING THE GAME AND VERIFYING THEY WORK AS INTENDED.

## Screenshots (if appropriate, e.g. map changes, tech tree changes, etc.):
