### PR TITLE
Non-functional fix to history/units/USA_1936_land_nsb.txt 

### DIFF
--- a/history/units/USA_1936_land_nsb.txt
+++ b/history/units/USA_1936_land_nsb.txt
@@ -186,7 +186,7 @@ units = {
 	division = {
 		division_name = {
 			is_name_ordered = yes
-			name_order = 1
+			name_order = 2
 		}
 		location = 9671
 		division_template = "Marine Brigade"


### PR DESCRIPTION
## Description
- Non-functional fix to history/units/USA_1936_land_nsb.txt to replace incorrect usage of 'name_order = 1' twice for marine divs in 1936 USA OOB

## Motivation and Context
- Minor cleanup
- Test my ability to do PRs

## How has this been tested?
- Set 2nd Mar div to use name_order = 3 and inserted a Schultzy nickname for that div in common/units/names_divisions/USA_names_divisions.txt; confirmed this affected the targeted division on reload
- Reverted the change to USA_names_divisions.txt and set div's name to use name_order = 2; reloaded again and confirmed it had proper name: 2nd Marine 'Follow Me' Division

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Equipment change (non-breaking change of equipment stats/year)
- [ ] New feature (non-breaking content/mechanic which adds functionality)
- [ ] Map change (change to states, provinces, air zones, sea zones, etc.)
- [ ] Balance change (change entirely for the sake of balance purposes)
- [ ] Localization change (change just to the text)
- [ ] AI change (change to any sort of AI behavior)
- [ ] Art/GUI change (change just to gfx/art/GUI/etc.)
- [ ] Save breaking change (fix or feature that would cause existing save games to break)
- [ ] Documentation/Administrative/Github update

## Checklist:
- [ ] My change requires a change to the roadmap.
- [ ] If the above is true, have updated the roadmap.
- [ ] My change requires a change to the spreadsheet(s).
- [ ] If the above is true, I have updated the spreadsheet(s).
- [ ] My change alters the balance of the mod.
- [ ] If the above is true, I have received approval for the balance change.
- [x] My code follows the code style of this project (neat, optimized, readable, etc.)
- [x] I HAVE TESTED THESE CHANGES BY RUNNING THE GAME AND VERIFYING THEY WORK AS INTENDED.

## Screenshots (if appropriate, e.g. map changes, tech tree changes, etc.):